### PR TITLE
[sdarq][frontend] Add nginx configuration, add step to Dockerfile

### DIFF
--- a/sdarq/frontend/Dockerfile
+++ b/sdarq/frontend/Dockerfile
@@ -10,4 +10,5 @@ RUN npm run lint
 RUN npm run build -- --prod
 
 FROM nginx:alpine
-COPY --from=node /app/dist /usr/share/nginx/html/
+COPY ./nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=node /app/dist /usr/share/nginx/html

--- a/sdarq/frontend/nginx.conf
+++ b/sdarq/frontend/nginx.conf
@@ -1,0 +1,8 @@
+server {
+  listen 80;
+  location / {
+    root /usr/share/nginx/html;
+    index index.html index.htm;
+    try_files $uri $uri/ /index.html =404;
+  }
+}


### PR DESCRIPTION
This PR introduces:

- An Nginx server configuration **nginx.conf** to Sdarq frontend.
- A new step in frontend Dockerfile to copy the Nginx configuration and locate it in the projects' root. 
