### PR TITLE
[DSEC-281][sdarq][backend] FIx Gunicorn

### DIFF
--- a/sdarq/backend/Dockerfile
+++ b/sdarq/backend/Dockerfile
@@ -13,7 +13,7 @@ ENV PORT 8080
 ENTRYPOINT [ \
   "gunicorn", \
   "--workers", "5", \
-  "--user", \
+  "--worker-tmp-dir", "/dev/shm", \
   "--worker-connections", "1000", \
   "--timeout", "360", \
   "--graceful-timeout", "360", \


### PR DESCRIPTION
This PR solves `Permission Error` for Gunicorn workers. 

[Reference](https://docs.gunicorn.org/en/stable/faq.html#how-do-i-avoid-gunicorn-excessively-blocking-in-os-fchmod)