### PR TITLE
change close_old_findings to True

### DIFF
--- a/zap/src/scan.py
+++ b/zap/src/scan.py
@@ -72,7 +72,7 @@ def defectdojo_upload(engagement_id: int, zap_filename: str, defect_dojo_key: st
                      file=absolute_path,
                      active=True,
                      verified=False,
-                     close_old_findings=False,
+                     close_old_findings=True,
                      skip_duplicates=True,
                      scan_date=str(datetime.today().strftime('%Y-%m-%d')),
                      tags="Zap_scan")


### PR DESCRIPTION
Change the import behavior so defect dojo closes old findings on a new scan, allowing only currently valid findings to show up in the UI.