### PR TITLE
[sdarq][zap] Replace engagement_id with product_id in PubSub

### DIFF
--- a/sdarq/backend/src/app.py
+++ b/sdarq/backend/src/app.py
@@ -473,7 +473,7 @@ def zap_scan():
                                   SCAN_TYPE=service_scan_type.name,
                                   SEVERITIES=severities,
                                   SLACK_CHANNEL=dev_slack_channel,
-                                  ENGAGEMENT_ID=product_id)
+                                  PRODUCT_ID=product_id)
                 logging.info("User %s requested to scan via ZAP %s service",
                              user_email, service_full_endpoint)
                 return ''

--- a/zap/src/trigger.py
+++ b/zap/src/trigger.py
@@ -79,7 +79,7 @@ def trigger_scan(  # pylint: disable=too-many-arguments
         URL=url,
         SCAN_TYPE=scan_type.name,
         SLACK_CHANNEL=slack_channel,
-        ENGAGEMENT_ID=product_id,
+        PRODUCT_ID=product_id,
     )
     future.add_done_callback(pubsub_callback(endpoint))
     return future


### PR DESCRIPTION
This PR:

Just improves the naming of PubSub messages.