### PR TITLE
remove codedx requirement

### DIFF
--- a/zap/src/scan.py
+++ b/zap/src/scan.py
@@ -371,7 +371,7 @@ def main(): # pylint: disable=too-many-locals
                               defect_dojo_key, defect_dojo_user, defect_dojo)
 
 
-            if codedx_api_key == '""':
+            if codedx_api_key == '':
                 slack_alert_without_report(
                     slack_token,
                     slack_channel,

--- a/zap/src/scan.py
+++ b/zap/src/scan.py
@@ -370,8 +370,8 @@ def main(): # pylint: disable=too-many-locals
             defectdojo_upload(product_id, zap_filename,
                               defect_dojo_key, defect_dojo_user, defect_dojo)
 
-
-            if codedx_api_key == '':
+            
+            if codedx_api_key == '""' or codedx_project == '':
                 slack_alert_without_report(
                     slack_token,
                     slack_channel,

--- a/zap/src/trigger.py
+++ b/zap/src/trigger.py
@@ -131,7 +131,7 @@ def trigger_scans(
         slack_channel = None
         try:
             codedx_project, slack_channel, scan_type, product_id = parse_tags(endpoint)
-            if codedx_project and (scan_type in scan_types):
+            if scan_type in scan_types:
                 future = trigger_scan(
                     publisher, endpoint, topic, codedx_project, scan_type, slack_channel, product_id
                 )


### PR DESCRIPTION
It is currently necessary to link a codedx project when setting up a scan to run with zap. This PR removes the requirement. It will still work with Codedx, but it will not longer be necessary.