### PR TITLE
[sdarq] Add blessed docker image for frontend

### DIFF
--- a/sdarq/frontend/Dockerfile
+++ b/sdarq/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts AS node
+FROM us.gcr.io/broad-dsp-gcr-public/base/nodejs:14-alpine AS node
 
 WORKDIR /app
 


### PR DESCRIPTION
This PR:

- Replaces SDARQ frontend old-based image with the AppSec blessed image without vulnerabilities [nodejs:14-alpine]