### PR TITLE
[DSEC-586] Add alerts for missing security controls

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,7 +3,8 @@ substitutions:
   _ORG_VIEWER_SA_EMAIL: '' # email of an existing Service Account with Org Viewer role
   _DNS_DOMAIN: '' # fully-resolved DNS domain name (e.g. appsec.example.org)
   _DNS_ZONE: '' # DNS zone name to be created/updated (e.g. appsec)
-  _CIS_CONTROLS_IGNORE: '' # CIS controls rule to ignore 
+  _CIS_CONTROLS_IGNORE: '' # CIS controls rule to ignore
+  _SECURITY_CONTROLS_IGNORE: '' # Security controls set to false ignore for some services
 
 options:
   machineType: N1_HIGHCPU_8
@@ -200,6 +201,8 @@ steps:
   waitFor: ['shared', 'sdarq-security-controls-image']
   entrypoint: ./deploy.sh
   dir: security-controls
+  env:
+  - SECURITY_CONTROLS_IGNORE=${_SECURITY_CONTROLS_IGNORE}
 
 # deploy CIS scanner resources
 - id: cis

--- a/sdarq/frontend/src/app/app-form/app-form.component.ts
+++ b/sdarq/frontend/src/app/app-form/app-form.component.ts
@@ -42,7 +42,14 @@ export class AppFormComponent implements OnInit {
     'service': result['Service'],
     'github': result['Github URL'],
     'product': '',
-    'dev_url': ''
+    'dev_url': '',
+    'burp': false,
+    'zap': false,
+    'cis_scanner': false,
+    'sourceclear': false,
+    'docker_scan': false,
+    'threat_model': false,
+    'sast': false
   };
   this.createNewSctService.createNewSCT(this.arrRequired).subscribe((createNewSCTResponse) => {
     console.log("Security Controls template created for this app")

--- a/sdarq/frontend/src/app/form/form.component.ts
+++ b/sdarq/frontend/src/app/form/form.component.ts
@@ -45,7 +45,14 @@ export class FormComponent implements OnInit {
       'service': result['Service'],
       'github': result['Github URL'],
       'product': result['Product'],
-      'dev_url': ''
+      'dev_url': '',
+      'burp': false,
+      'zap': false,
+      'cis_scanner': false,
+      'sourceclear': false,
+      'docker_scan': false,
+      'threat_model': false,
+      'sast': false
     };
     this.createNewSctService.createNewSCT(this.arrRequired).subscribe((createNewSCTResponse) => {
       console.log("Security Controls template created for this service")

--- a/security-controls/Dockerfile
+++ b/security-controls/Dockerfile
@@ -13,6 +13,10 @@ RUN apt-get update -q && \
       libffi-dev && \
     rm -rf /var/lib/apt/lists/*
 
+RUN pip3 install pylint 
+
 COPY *.py ./
+
+RUN pylint --disable=C0301 /*.py
 
 ENTRYPOINT ["python3", "-m", "entrypoint"]

--- a/security-controls/deployment.yaml
+++ b/security-controls/deployment.yaml
@@ -60,7 +60,7 @@ spec:
           containers:
           - name: security-controls
             image: ${SDARQ_SECURITY_CONTROLS}
-            command: ['python3', '/notifier.py']
+            command: ['python3', '/notify.py']
             envFrom:
             - secretRef:
                 name: ${SERVICE_SECRET}

--- a/security-controls/deployment.yaml
+++ b/security-controls/deployment.yaml
@@ -64,3 +64,6 @@ spec:
             envFrom:
             - secretRef:
                 name: ${SERVICE_SECRET}
+            env:
+            - name: CIS_CONTROLS_IGNORE
+              value: ${CIS_CONTROLS_IGNORE}

--- a/security-controls/deployment.yaml
+++ b/security-controls/deployment.yaml
@@ -39,3 +39,28 @@ spec:
             env:
               - name: DEFECT_DOJO_URL
                 value: ${DEFECT_DOJO_URL}
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name:  ${SERVICE}
+  namespace: ${NAMESPACE}
+spec:
+  schedule: "0 1 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: ${SERVICE_ACCOUNT}
+          runtimeClassName: gvisor
+          nodeSelector:
+            cloud.google.com/gke-nodepool: batch
+          restartPolicy: OnFailure
+
+          containers:
+          - name: security-controls-notifier
+            image: ${SDARQ_SECURITY_CONTROLS}
+            command: ['python3', '/notify.py']
+            envFrom:
+            - secretRef:
+                name: ${SERVICE_SECRET}

--- a/security-controls/deployment.yaml
+++ b/security-controls/deployment.yaml
@@ -43,7 +43,7 @@ spec:
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name:  ${SERVICE}
+  name:  ${SERVICE}-notifier
   namespace: ${NAMESPACE}
 spec:
   schedule: "0 1 * * *"
@@ -58,9 +58,9 @@ spec:
           restartPolicy: OnFailure
 
           containers:
-          - name: security-controls-notifier
+          - name: security-controls
             image: ${SDARQ_SECURITY_CONTROLS}
-            command: ['python3', '/notify.py']
+            command: ['python3', '/notifier.py']
             envFrom:
             - secretRef:
                 name: ${SERVICE_SECRET}

--- a/security-controls/deployment.yaml
+++ b/security-controls/deployment.yaml
@@ -43,10 +43,10 @@ spec:
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name:  ${SERVICE}-notifier
+  name:  security-controls-trigger-weekly
   namespace: ${NAMESPACE}
 spec:
-  schedule: "0 1 * * *"
+  schedule: "0 7 * * 6"
   jobTemplate:
     spec:
       template:
@@ -65,5 +65,5 @@ spec:
             - secretRef:
                 name: ${SERVICE_SECRET}
             env:
-            - name: CIS_CONTROLS_IGNORE
-              value: ${CIS_CONTROLS_IGNORE}
+            - name: SECURITY_CONTROLS_IGNORE
+              value: ${SECURITY_CONTROLS_IGNORE}

--- a/security-controls/entrypoint.py
+++ b/security-controls/entrypoint.py
@@ -3,10 +3,10 @@
 This module
 - will get all products that have srlc & zap tag and update security controls column for all services/apps
 """
-import os, logging
+import os
+import logging
 import requests
 from google.cloud import firestore
-
 
 
 def update_dependecies_scan_values(defect_dojo_key: str, defect_dojo: str, security_controls_firestore_collection: str, dep_scan_link: str, defect_dojo_host: str):
@@ -14,26 +14,27 @@ def update_dependecies_scan_values(defect_dojo_key: str, defect_dojo: str, secur
     Get all DefectDojo projects with srcclr tag
     Update all services 3rd party dependencies scan in security controls with the result link to DD
     '''
-    db = firestore.Client()
-    products_endpoint = "{0}/api/v2/products/?tag=srcclr".format(defect_dojo)
+    firestore_docs = firestore.Client()
+    products_endpoint = f"{defect_dojo}/api/v2/products/?tag=srcclr"
 
     headers = {
         "content-type": "application/json",
-        "Authorization": "Token {0}".format(str(defect_dojo_key)),
+        "Authorization": f"Token {str(defect_dojo_key)}",
     }
 
     res = requests.get(products_endpoint,
-                       headers=headers, verify=True)
+                       headers=headers, verify=True, timeout=15)
 
     for product in res.json()['results']:
-        doc_ref = db.collection(
+        doc_ref = firestore_docs.collection(
             security_controls_firestore_collection).document(product['name'].lower())
         doc = doc_ref.get()
         if bool(doc.to_dict()) is True:
-            logging.info("Third party dependecies scan value and link updated for %s ", product['name'])
+            logging.info(
+                "Third party dependecies scan value and link updated for %s ", product['name'])
             doc_ref.set({
-                u'sourceclear': True,
-                u'sourceclear_link': '{0}/product/{1}/finding/{2}'.format(defect_dojo_host, str(product['id']), dep_scan_link)
+                'sourceclear': True,
+                'sourceclear_link': f'{defect_dojo_host}/product/{str(product["id"])}/finding/{dep_scan_link}'
             }, merge=True)
 
 
@@ -42,27 +43,27 @@ def update_dast_values(defect_dojo_key: str, defect_dojo: str, security_controls
     Get all DefectDojo projects with zap tag
     Update all services DAST value in security controls with the result link to DD
     '''
-    db = firestore.Client()
-    products_endpoint = "{0}/api/v2/products/?tag=zap".format(defect_dojo)
+    firestore_docs = firestore.Client()
+    products_endpoint = f"{defect_dojo}/api/v2/products/?tag=zap"
 
     headers = {
         "content-type": "application/json",
-        "Authorization": "Token {0}".format(str(defect_dojo_key)),
+        "Authorization": f"Token {str(defect_dojo_key)}",
     }
 
     res = requests.get(products_endpoint,
-                       headers=headers, verify=True)
+                       headers=headers, verify=True, timeout=15)
     for product in res.json()['results']:
-        doc_ref = db.collection(
+        doc_ref = firestore_docs.collection(
             security_controls_firestore_collection).document(product['name'].lower())
         doc = doc_ref.get()
         if bool(doc.to_dict()) is True:
-            logging.info("DAST value and link updated for %s ", product['name'])
+            logging.info("DAST value and link updated for %s ",
+                         product['name'])
             doc_ref.set({
-                u'zap': True,
-                u'vulnerability_management': '{0}/product/{1}/finding/{2}'.format(defect_dojo_host, str(product['id']), dast_link)
+                'zap': True,
+                'vulnerability_management': f'{defect_dojo_host}/product/{str(product["id"])}/finding/{dast_link}'
             }, merge=True)
-
 
 
 def main():
@@ -79,9 +80,11 @@ def main():
     # configure logging
     logging.basicConfig(level=logging.INFO)
 
-    update_dependecies_scan_values(defect_dojo_key, defect_dojo, security_controls_firestore_collection, dep_scan_link, defect_dojo_host)
+    update_dependecies_scan_values(
+        defect_dojo_key, defect_dojo, security_controls_firestore_collection, dep_scan_link, defect_dojo_host)
 
-    update_dast_values(defect_dojo_key, defect_dojo, security_controls_firestore_collection, dast_link, defect_dojo_host)
+    update_dast_values(defect_dojo_key, defect_dojo,
+                       security_controls_firestore_collection, dast_link, defect_dojo_host)
 
 
 if __name__ == "__main__":

--- a/security-controls/notify.py
+++ b/security-controls/notify.py
@@ -4,20 +4,18 @@ This module
 - will notify AppSec team in slack for all security controls that are not implemented for specific services
 """
 
-import os, logging
-import requests
+import os
 from google.cloud import firestore
 from slack_sdk import WebClient
 
 
 def notify_appsec(security_controls_firestore_collection, slack_token, slack_channel, security_controls_ignore_final_list):
     db = firestore.Client()
-    data = []
 
     docs = db.collection(security_controls_firestore_collection).stream()
     for doc in docs:
         for key in doc.to_dict():
-            if doc.to_dict()[key] == False:
+            if doc.to_dict()[key] is False:
                 service_seccon =  f"{doc.to_dict()['service']}_{key}"
                 if service_seccon in security_controls_ignore_list:
                     continue
@@ -55,3 +53,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/security-controls/notify.py
+++ b/security-controls/notify.py
@@ -17,7 +17,7 @@ def notify_appsec(security_controls_firestore_collection, slack_token, slack_cha
         for key in doc.to_dict():
             if doc.to_dict()[key] is False:
                 service_seccon =  f"{doc.to_dict()['service']}_{key}"
-                if service_seccon in security_controls_ignore_list:
+                if service_seccon in security_controls_ignore_final_list:
                     continue
                 client = WebClient(token=slack_token)
                 client.chat_postMessage(
@@ -50,7 +50,7 @@ def main():
     security_controls_ignore_final_list = security_controls_ignore_list.split(",")
 
     notify_appsec(security_controls_firestore_collection, slack_token, slack_channel, security_controls_ignore_final_list)
+    
 
 if __name__ == "__main__":
     main()
-

--- a/security-controls/notify.py
+++ b/security-controls/notify.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""
+This module
+- will notify AppSec team in slack for all security controls that are not implemented for specific services
+"""
+
+import os, logging
+import requests
+from google.cloud import firestore
+from slack_sdk import WebClient
+
+
+def notify_appsec(security_controls_firestore_collection, slack_token, slack_channel, security_controls_ignore_final_list):
+    db = firestore.Client()
+    data = []
+
+    docs = db.collection(security_controls_firestore_collection).stream()
+    for doc in docs:
+        for key in doc.to_dict():
+            if doc.to_dict()[key] == False:
+                service_seccon =  f"{doc.to_dict()['service']}_{key}"
+                if service_seccon in security_controls_ignore_list:
+                    continue
+                else
+                    client = WebClient(token=slack_token)
+                    client.chat_postMessage(
+                        channel=slack_channel,
+                        attachments=[{"blocks": [
+                            {
+                                "type": "section",
+                                "text": {
+                                    "type": "mrkdwn",
+                                    "text":
+                                        f"Security control {key} is not integrated for this service/app {doc.to_dict()['service']}!",
+                                }
+                            },
+                            {
+                                "type": "divider"
+                            },
+                        ], "color": "#C31818"}]
+                    )
+
+
+
+def main():
+    """
+    Implements the entrypoint.
+    """
+    security_controls_firestore_collection = os.environ['SC_FIRESTORE_COLLECTION']
+    slack_token = os.getenv('SLACK_TOKEN')
+    slack_channel = os.getenv('SLACK_CHANNEL')
+    security_controls_ignore_list = os.getenv('SECURITY_CONTROLS_IGNORE', '')
+    security_controls_ignore_final_list = security_controls_ignore_list.split(",")
+
+    notify_appsec(security_controls_firestore_collection, slack_token, slack_channel, security_controls_ignore_final_list)
+
+if __name__ == "__main__":
+    main()

--- a/security-controls/notify.py
+++ b/security-controls/notify.py
@@ -32,8 +32,7 @@ def notify_appsec(security_controls_firestore_collection, slack_token, slack_cha
     for doc in docs:
         for key in doc.to_dict():
             if doc.to_dict()[key] is False:
-                service_name = doc.to_dict()['service'].strip(' ').replace(' ', '-')
-                print(service_name)
+                service_name = doc.to_dict()['service'].strip(' ').replace(' ', '_')
                 service_seccon = f"{service_name}_{key}"
                 if service_seccon in security_controls_ignore_final_list:
                     continue

--- a/security-controls/notify.py
+++ b/security-controls/notify.py
@@ -17,18 +17,21 @@ def notify_appsec(security_controls_firestore_collection, slack_token, slack_cha
         for key in doc.to_dict():
             if doc.to_dict()[key] is False:
                 service_seccon =  f"{doc.to_dict()['service']}_{key}"
+                print(service_seccon)
                 if service_seccon in security_controls_ignore_final_list:
+                    print(security_controls_ignore_final_list)
                     continue
                 client = WebClient(token=slack_token)
                 client.chat_postMessage(
                     channel=slack_channel,
+                    text="Security Control not integrated",
                     attachments=[{"blocks": [
                         {
                             "type": "section",
                             "text": {
                                 "type": "mrkdwn",
                                 "text":
-                                    f"Security control {key} is not integrated for this service/app {doc.to_dict()['service']}!",
+                                    f"Security control `{key}` is not integrated for {doc.to_dict()['service']}!",
                             }
                         },
                         {
@@ -50,7 +53,7 @@ def main():
     security_controls_ignore_final_list = security_controls_ignore_list.split(",")
 
     notify_appsec(security_controls_firestore_collection, slack_token, slack_channel, security_controls_ignore_final_list)
-    
+
 
 if __name__ == "__main__":
     main()

--- a/security-controls/notify.py
+++ b/security-controls/notify.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """
 This module
-- will notify AppSec team in slack for all security controls that are not implemented for all services
+- will notify AppSec team in Slack for all security controls,
+  that are not implemented for all services
 """
 
 import os
@@ -16,8 +17,8 @@ def notify_appsec(security_controls_firestore_collection, slack_token, slack_cha
     Report to a Slack channel
     """
 
-    db = firestore.Client()
-    docs = db.collection(security_controls_firestore_collection).stream()
+    firestore_docs = firestore.Client()
+    docs = firestore_docs.collection(security_controls_firestore_collection).stream()
     keyword_maps = {
         "burp": "security manual pentest",
         "zap": "DAST",
@@ -31,10 +32,10 @@ def notify_appsec(security_controls_firestore_collection, slack_token, slack_cha
     for doc in docs:
         for key in doc.to_dict():
             if doc.to_dict()[key] is False:
-                service_seccon =  f"{doc.to_dict()['service']}_{key}"
+                service_seccon = f"{doc.to_dict()['service']}_{key}"
                 if service_seccon in security_controls_ignore_final_list:
                     continue
-                
+
                 client = WebClient(token=slack_token)
                 client.chat_postMessage(
                     channel=slack_channel,
@@ -52,7 +53,6 @@ def notify_appsec(security_controls_firestore_collection, slack_token, slack_cha
                 )
 
 
-
 def main():
     """
     Implements the entrypoint.
@@ -63,7 +63,8 @@ def main():
     security_controls_ignore_list = os.getenv('SECURITY_CONTROLS_IGNORE', '')
     security_controls_ignore_final_list = security_controls_ignore_list.split(",")
 
-    notify_appsec(security_controls_firestore_collection, slack_token, slack_channel, security_controls_ignore_final_list)
+    notify_appsec(security_controls_firestore_collection, slack_token,
+                  slack_channel, security_controls_ignore_final_list)
 
 
 if __name__ == "__main__":

--- a/security-controls/notify.py
+++ b/security-controls/notify.py
@@ -35,6 +35,7 @@ def notify_appsec(security_controls_firestore_collection, slack_token, slack_cha
                 service_name = doc.to_dict()['service'].strip(' ').replace(' ','_')
                 service_seccon = f"{service_name}_{key}"
                 print(service_seccon)
+                print(security_controls_ignore_final_list)
                 if service_seccon in security_controls_ignore_final_list:
                     continue
 

--- a/security-controls/notify.py
+++ b/security-controls/notify.py
@@ -12,8 +12,8 @@ from slack_sdk import WebClient
 def notify_appsec(security_controls_firestore_collection, slack_token, slack_channel, security_controls_ignore_final_list):
     """
     Get all security controls
-    Checks which security controls are set to false and not part of a FP list
-    Reports to Slack channel
+    Check security controls that are set to false and not part of a FP list
+    Report to a Slack channel
     """
 
     db = firestore.Client()
@@ -38,14 +38,14 @@ def notify_appsec(security_controls_firestore_collection, slack_token, slack_cha
                 client = WebClient(token=slack_token)
                 client.chat_postMessage(
                     channel=slack_channel,
-                    text="AppSec reminder",
+                    text="AppSec weekly reminder",
                     attachments=[{"blocks": [
                         {
                             "type": "section",
                             "text": {
                                 "type": "mrkdwn",
                                 "text":
-                                    f"Security control `{keyword_maps[key]}` is not integrated/impplemented for `{doc.to_dict()['service']}`!",
+                                    f"Security control `{keyword_maps[key]}` is not integrated/implemented for `{doc.to_dict()['service'].capitalize()}`.",
                             }
                         },
                     ], "color": "#C31818"}]

--- a/security-controls/notify.py
+++ b/security-controls/notify.py
@@ -21,24 +21,23 @@ def notify_appsec(security_controls_firestore_collection, slack_token, slack_cha
                 service_seccon =  f"{doc.to_dict()['service']}_{key}"
                 if service_seccon in security_controls_ignore_list:
                     continue
-                else
-                    client = WebClient(token=slack_token)
-                    client.chat_postMessage(
-                        channel=slack_channel,
-                        attachments=[{"blocks": [
-                            {
-                                "type": "section",
-                                "text": {
-                                    "type": "mrkdwn",
-                                    "text":
-                                        f"Security control {key} is not integrated for this service/app {doc.to_dict()['service']}!",
-                                }
-                            },
-                            {
-                                "type": "divider"
-                            },
-                        ], "color": "#C31818"}]
-                    )
+                client = WebClient(token=slack_token)
+                client.chat_postMessage(
+                    channel=slack_channel,
+                    attachments=[{"blocks": [
+                        {
+                            "type": "section",
+                            "text": {
+                                "type": "mrkdwn",
+                                "text":
+                                    f"Security control {key} is not integrated for this service/app {doc.to_dict()['service']}!",
+                            }
+                        },
+                        {
+                            "type": "divider"
+                        },
+                    ], "color": "#C31818"}]
+                )
 
 
 

--- a/security-controls/notify.py
+++ b/security-controls/notify.py
@@ -13,24 +13,34 @@ def notify_appsec(security_controls_firestore_collection, slack_token, slack_cha
     db = firestore.Client()
     docs = db.collection(security_controls_firestore_collection).stream()
 
+    keyword_maps = {
+        "burp": "security manual pentest",
+        "zap": "DAST",
+        "cis_scanner": "CIS scanner",
+        "sourceclear": "3rd party dependencies scan",
+        "docker_scan": "container image scan",
+        "threat_model": "threat model",
+        "sast": "SAST"
+    }
+
     for doc in docs:
         for key in doc.to_dict():
             if doc.to_dict()[key] is False:
                 service_seccon =  f"{doc.to_dict()['service']}_{key}"
                 if service_seccon in security_controls_ignore_final_list:
-                    print(security_controls_ignore_final_list)
                     continue
+                
                 client = WebClient(token=slack_token)
                 client.chat_postMessage(
                     channel=slack_channel,
-                    text="SDARQ Security Controls",
+                    text="AppSec reminder",
                     attachments=[{"blocks": [
                         {
                             "type": "section",
                             "text": {
                                 "type": "mrkdwn",
                                 "text":
-                                    f"Security control `{key}` is not integrated for {doc.to_dict()['service']}!",
+                                    f"Security control `{keyword_maps[key]}` is not integrated for {doc.to_dict()['service']}!",
                             }
                         },
                         {

--- a/security-controls/notify.py
+++ b/security-controls/notify.py
@@ -32,15 +32,16 @@ def notify_appsec(security_controls_firestore_collection, slack_token, slack_cha
     for doc in docs:
         for key in doc.to_dict():
             if doc.to_dict()[key] is False:
-                service_name = doc.to_dict()['service'].strip(' ').replace(' ', '_')
+                service_name = doc.to_dict()['service'].strip(' ').replace(' ','_')
                 service_seccon = f"{service_name}_{key}"
+                print(service_seccon)
                 if service_seccon in security_controls_ignore_final_list:
                     continue
 
                 client = WebClient(token=slack_token)
                 client.chat_postMessage(
                     channel=slack_channel,
-                    text="AppSec weekly reminder",
+                    text="AppSec Action Required",
                     attachments=[{"blocks": [
                         {
                             "type": "section",

--- a/security-controls/notify.py
+++ b/security-controls/notify.py
@@ -42,7 +42,7 @@ def notify_appsec(security_controls_firestore_collection, slack_token, slack_cha
                 client = WebClient(token=slack_token)
                 client.chat_postMessage(
                     channel=slack_channel,
-                    text="AppSec Action Required",
+                    text="*AppSec Action Required*",
                     attachments=[{"blocks": [
                         {
                             "type": "section",

--- a/security-controls/notify.py
+++ b/security-controls/notify.py
@@ -11,20 +11,19 @@ from slack_sdk import WebClient
 
 def notify_appsec(security_controls_firestore_collection, slack_token, slack_channel, security_controls_ignore_final_list):
     db = firestore.Client()
-
     docs = db.collection(security_controls_firestore_collection).stream()
+
     for doc in docs:
         for key in doc.to_dict():
             if doc.to_dict()[key] is False:
                 service_seccon =  f"{doc.to_dict()['service']}_{key}"
-                print(service_seccon)
                 if service_seccon in security_controls_ignore_final_list:
                     print(security_controls_ignore_final_list)
                     continue
                 client = WebClient(token=slack_token)
                 client.chat_postMessage(
                     channel=slack_channel,
-                    text="Security Control not integrated",
+                    text="SDARQ Security Controls",
                     attachments=[{"blocks": [
                         {
                             "type": "section",

--- a/security-controls/notify.py
+++ b/security-controls/notify.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 This module
-- will notify AppSec team in slack for all security controls that are not implemented for specific services
+- will notify AppSec team in slack for all security controls that are not implemented for all services
 """
 
 import os
@@ -10,9 +10,14 @@ from slack_sdk import WebClient
 
 
 def notify_appsec(security_controls_firestore_collection, slack_token, slack_channel, security_controls_ignore_final_list):
+    """
+    Get all security controls
+    Checks which security controls are set to false and not part of a FP list
+    Reports to Slack channel
+    """
+
     db = firestore.Client()
     docs = db.collection(security_controls_firestore_collection).stream()
-
     keyword_maps = {
         "burp": "security manual pentest",
         "zap": "DAST",
@@ -40,11 +45,8 @@ def notify_appsec(security_controls_firestore_collection, slack_token, slack_cha
                             "text": {
                                 "type": "mrkdwn",
                                 "text":
-                                    f"Security control `{keyword_maps[key]}` is not integrated for {doc.to_dict()['service']}!",
+                                    f"Security control `{keyword_maps[key]}` is not integrated/impplemented for `{doc.to_dict()['service']}`!",
                             }
-                        },
-                        {
-                            "type": "divider"
                         },
                     ], "color": "#C31818"}]
                 )

--- a/security-controls/notify.py
+++ b/security-controls/notify.py
@@ -33,6 +33,7 @@ def notify_appsec(security_controls_firestore_collection, slack_token, slack_cha
         for key in doc.to_dict():
             if doc.to_dict()[key] is False:
                 service_name = doc.to_dict()['service'].strip(' ').replace(' ', '-')
+                print(service_name)
                 service_seccon = f"{service_name}_{key}"
                 if service_seccon in security_controls_ignore_final_list:
                     continue

--- a/security-controls/notify.py
+++ b/security-controls/notify.py
@@ -32,7 +32,8 @@ def notify_appsec(security_controls_firestore_collection, slack_token, slack_cha
     for doc in docs:
         for key in doc.to_dict():
             if doc.to_dict()[key] is False:
-                service_seccon = f"{doc.to_dict()['service']}_{key}"
+                service_name = doc.to_dict()['service'].strip(' ').replace(' ', '-')
+                service_seccon = f"{service_name}_{key}"
                 if service_seccon in security_controls_ignore_final_list:
                     continue
 

--- a/security-controls/requirements.txt
+++ b/security-controls/requirements.txt
@@ -2,3 +2,4 @@ requests
 google-api-core[grpc] < 2.0.0dev
 google-cloud-firestore
 google-cloud-resource-manager
+slack_sdk


### PR DESCRIPTION
This PR:
- Deploys a CronJob in the GKE cluster that runs weekly
- The CronJob will report in a Slack channel all security controls that are not implemented/integrated for a service/app
- In case some security controls should not be reported weekly (or in case there is a false positive), an AllowList `SECURITY_CONTROLS_IGNORE` is added to the cloud build.
- When a new service/app is created through questionnaires, some security controls will be set to false automatically and reported to the Slack channel as reminders. 