### PR TITLE
[sdarq][backend] Update flask

### DIFF
--- a/sdarq/backend/requirements.txt
+++ b/sdarq/backend/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.0.1
+Flask==2.3.2
 Flask-Limiter
 requests
 requests-oauthlib==1.0.0


### PR DESCRIPTION
This PR:
- Updates FLASK from `2.3.1` to `2.3.2` to address [CVE-2023-30861](https://github.com/advisories/GHSA-m2qf-hxjv-5gpq) 