### PR TITLE
[DSEC-654] Prepare zapscans for azure apps

### DIFF
--- a/zap/src/terra_auth.py
+++ b/zap/src/terra_auth.py
@@ -6,7 +6,7 @@ import urllib3
 def terra_is_registered(token, env):
     is_registered = False
     url = ""
-    if env.lower() is "dev":
+    if env.lower() == "dev":
         url = "https://sam.dsde-dev.broadinstitute.org/register/user/v2/self/termsOfServiceComplianceStatus"
     else:
         url = "https://sam.dsde-prod.broadinstitute.org/register/user/v2/self/termsOfServiceComplianceStatus"
@@ -25,7 +25,7 @@ def terra_register_sa(token, env):
     url = ""
     # Usually dev URLs have "dev" in them.
     # This will only support dev and prod environments currently
-    if env.lower() is "dev":
+    if env.lower() == "dev":
         url = "https://firecloud-orchestration.dsde-dev.broadinstitute.org/register/profile"
     else:
         url = "https://api.firecloud.org"
@@ -52,14 +52,14 @@ def terra_register_sa(token, env):
         },
         data=profile_json)
         if resp.status_code == 200:
-            is_registered = terra_is_registered(token)
+            is_registered = terra_is_registered(token, env)
     return is_registered
     
 
 def terra_auth_logged_in(token, env):
     logged_in = False
     url = ""
-    if env.lower() is "dev":
+    if env.lower() == "dev":
         url = "https://sam.dsde-dev.broadinstitute.org/register/user/v2/self/info"
     else:
         url = "https://sam.dsde-prod.broadinstitute.org/register/user/v2/self/info"
@@ -78,7 +78,7 @@ def terra_auth_logged_in(token, env):
 def terra_tos(token, env):
     tos = False
     url = ""
-    if env.lower() is "dev":
+    if env.lower() == "dev":
         url = "https://sam.dsde-dev.broadinstitute.org/register/user/v1/termsofservice"
     else:
         url = "https://sam.dsde-prod.broadinstitute.org/register/user/v1/termsofservice"

--- a/zap/src/terra_auth.py
+++ b/zap/src/terra_auth.py
@@ -3,13 +3,25 @@ import urllib3
 
 # Library for ensuring the service account used for authentication is registered and logged in.
 
-def terra_is_registered(token):
+def terra_is_registered(token, env):
     is_registered = False
-
+    url = ""
+    if env.lower() is "dev":
+        url = "https://sam.dsde-dev.broadinstitute.org/register/user/v2/self/termsOfServiceComplianceStatus"
+    else:
+        url = "https://sam.dsde-prod.broadinstitute.org/register/user/v2/self/termsOfServiceComplianceStatus"
+    resp = urllib3.response(
+        "GET",
+        url,
+        headers={
+            "Authorization": token
+        })
+    if resp.status_code == 200:
+        is_registered = True
     return is_registered
 
 def terra_register_sa(token, env):
-    is_registered = terra_is_registered(token)
+    is_registered = terra_is_registered(token, env)
     url = ""
     # Usually dev URLs have "dev" in them.
     # This will only support dev and prod environments currently
@@ -46,13 +58,14 @@ def terra_register_sa(token, env):
 
 def terra_auth_logged_in(token, env):
     logged_in = False
+    url = ""
     if env.lower() is "dev":
         url = "https://sam.dsde-dev.broadinstitute.org/register/user/v2/self/info"
     else:
         url = "https://sam.dsde-prod.broadinstitute.org/register/user/v2/self/info"
     resp = urllib3.response(
         "GET",
-        "",
+        url,
         headers={
             "Authorization": token
         }

--- a/zap/src/terra_auth.py
+++ b/zap/src/terra_auth.py
@@ -1,0 +1,84 @@
+
+import urllib3
+
+# Library for ensuring the service account used for authentication is registered and logged in.
+
+def terra_is_registered(token):
+    is_registered = False
+
+    return is_registered
+
+def terra_register_sa(token, env):
+    is_registered = terra_is_registered(token)
+    url = ""
+    # Usually dev URLs have "dev" in them.
+    # This will only support dev and prod environments currently
+    if env.lower() is "dev":
+        url = "https://firecloud-orchestration.dsde-dev.broadinstitute.org/register/profile"
+    else:
+        url = "https://api.firecloud.org"
+    if is_registered is False:
+        # Login
+
+        profile_json = {"firstName": "test",
+                "lastName": "service account",
+                "title": "None",
+                "contactEmail": "",
+                "institute": "None",
+                "institutionalProgram": "None",
+                "programLocationCity": "None",
+                "programLocationState": "None",
+                "programLocationCountry": "None",
+                "pi": "None",
+                "nonProfitStatus": "false"}
+        resp = urllib3.response(
+        "POST",
+        url,
+        headers={
+            "Authorization": token,
+            "Content-Type": "application/json"
+        },
+        data=profile_json)
+        if resp.status_code == 200:
+            is_registered = terra_is_registered(token)
+    return is_registered
+    
+
+def terra_auth_logged_in(token, env):
+    logged_in = False
+    if env.lower() is "dev":
+        url = "https://sam.dsde-dev.broadinstitute.org/register/user/v2/self/info"
+    else:
+        url = "https://sam.dsde-prod.broadinstitute.org/register/user/v2/self/info"
+    resp = urllib3.response(
+        "GET",
+        "",
+        headers={
+            "Authorization": token
+        }
+    )
+    if resp.status is 200:
+        logged_in = True
+    
+    return logged_in
+
+def terra_tos(token, env):
+    tos = False
+    url = ""
+    if env.lower() is "dev":
+        url = "https://sam.dsde-dev.broadinstitute.org/register/user/v1/termsofservice"
+    else:
+        url = "https://sam.dsde-prod.broadinstitute.org/register/user/v1/termsofservice"
+
+    resp = urllib3.response(
+        "POST",
+        url,
+        headers={
+            "Authorization": token,
+            "Content-Type": "application/json"
+        },
+        data="app.terra.bio/#terms-of-service"
+    )
+    if resp.status_code == 200:
+        tos = True
+    return tos

--- a/zap/src/terra_auth.py
+++ b/zap/src/terra_auth.py
@@ -1,18 +1,25 @@
-
+"""
+Provides methods for validating that an account is logged in,
+and registered with Terra.
+"""
 import urllib3
 
 # Library for ensuring the service account used for authentication is registered and logged in.
 
 def terra_is_registered(token, env):
+    """
+    Checks if a user is registered with Terra.
+    Will return True if registered, False if not.
+    """
     is_registered = False
     url = ""
     if env.lower() == "dev":
-        url = "https://sam.dsde-dev.broadinstitute.org/register/user/v2/self/termsOfServiceComplianceStatus"
+        url = "https://sam.dsde-dev.broadinstitute.org/"
     else:
-        url = "https://sam.dsde-prod.broadinstitute.org/register/user/v2/self/termsOfServiceComplianceStatus"
-    resp = urllib3.response(
+        url = "https://sam.dsde-prod.broadinstitute.org/"
+    resp = urllib3.request(
         "GET",
-        url,
+        url + "register/user/v2/self/termsOfServiceComplianceStatus",
         headers={
             "Authorization": token
         })
@@ -21,6 +28,10 @@ def terra_is_registered(token, env):
     return is_registered
 
 def terra_register_sa(token, env):
+    """
+    Registers a user with Terra if they are not yet registered.
+    Returns True if successfull, False if registration fails.
+    """
     is_registered = terra_is_registered(token, env)
     url = ""
     # Usually dev URLs have "dev" in them.
@@ -43,7 +54,7 @@ def terra_register_sa(token, env):
                 "programLocationCountry": "None",
                 "pi": "None",
                 "nonProfitStatus": "false"}
-        resp = urllib3.response(
+        resp = urllib3.request(
         "POST",
         url,
         headers={
@@ -54,28 +65,36 @@ def terra_register_sa(token, env):
         if resp.status_code == 200:
             is_registered = terra_is_registered(token, env)
     return is_registered
-    
+
 
 def terra_auth_logged_in(token, env):
+    """
+    Validates whether a user is logged into Terra.
+    Equivalent to checking if bearer token is still valid.
+    """
     logged_in = False
     url = ""
     if env.lower() == "dev":
         url = "https://sam.dsde-dev.broadinstitute.org/register/user/v2/self/info"
     else:
         url = "https://sam.dsde-prod.broadinstitute.org/register/user/v2/self/info"
-    resp = urllib3.response(
+    resp = urllib3.request(
         "GET",
         url,
         headers={
             "Authorization": token
         }
     )
-    if resp.status is 200:
+    if resp.status == 200:
         logged_in = True
-    
+
     return logged_in
 
 def terra_tos(token, env):
+    """
+    Accepts the Terra TOS.
+    There does not appear to be a problem with accepting it many times.
+    """
     tos = False
     url = ""
     if env.lower() == "dev":
@@ -83,7 +102,7 @@ def terra_tos(token, env):
     else:
         url = "https://sam.dsde-prod.broadinstitute.org/register/user/v1/termsofservice"
 
-    resp = urllib3.response(
+    resp = urllib3.request(
         "POST",
         url,
         headers={

--- a/zap/src/terra_auth.py
+++ b/zap/src/terra_auth.py
@@ -2,7 +2,7 @@
 Provides methods for validating that an account is logged in,
 and registered with Terra.
 """
-import urllib3
+import requests
 
 # Library for ensuring the service account used for authentication is registered and logged in.
 
@@ -17,7 +17,7 @@ def terra_is_registered(token, env):
         url = "https://sam.dsde-dev.broadinstitute.org/"
     else:
         url = "https://sam.dsde-prod.broadinstitute.org/"
-    resp = urllib3.request(
+    resp = requests.request(
         "GET",
         url + "register/user/v2/self/termsOfServiceComplianceStatus",
         headers={
@@ -54,7 +54,7 @@ def terra_register_sa(token, env):
                 "programLocationCountry": "None",
                 "pi": "None",
                 "nonProfitStatus": "false"}
-        resp = urllib3.request(
+        resp = requests.request(
         "POST",
         url,
         headers={
@@ -78,7 +78,7 @@ def terra_auth_logged_in(token, env):
         url = "https://sam.dsde-dev.broadinstitute.org/register/user/v2/self/info"
     else:
         url = "https://sam.dsde-prod.broadinstitute.org/register/user/v2/self/info"
-    resp = urllib3.request(
+    resp = requests.request(
         "GET",
         url,
         headers={
@@ -102,14 +102,14 @@ def terra_tos(token, env):
     else:
         url = "https://sam.dsde-prod.broadinstitute.org/register/user/v1/termsofservice"
 
-    resp = urllib3.request(
+    resp = requests.request(
         "POST",
         url,
         headers={
             "Authorization": token,
             "Content-Type": "application/json"
         },
-        data="app.terra.bio/#terms-of-service"
+        data='"app.terra.bio/#terms-of-service"'
     )
     if resp.status_code == 200:
         tos = True

--- a/zap/src/terra_auth.py
+++ b/zap/src/terra_auth.py
@@ -32,6 +32,7 @@ def terra_register_sa(token, env):
     Registers a user with Terra if they are not yet registered.
     Returns True if successfull, False if registration fails.
     """
+    is_registered = False
     is_registered = terra_is_registered(token, env)
     url = ""
     # Usually dev URLs have "dev" in them.

--- a/zap/src/trigger.py
+++ b/zap/src/trigger.py
@@ -155,11 +155,11 @@ def main():
         level=logging.INFO,
         format=f"%(levelname)-8s [zap-trigger] %(message)s",
     )
-    defect_dojo_url = getenv("DEFECT_DOJO_URL")
+    defectdojo_url = getenv("DEFECT_DOJO_URL")
     defect_dojo_key = getenv("DEFECT_DOJO_KEY")
     zap_topic = getenv("ZAP_TOPIC_NAME")
     gcp_project = getenv("GCP_PROJECT_ID")
-    logging.info(f"Cron job running. Dojo {defect_dojo_url} Topic {zap_topic} Project {gcp_project}")
+    logging.info(f"Cron job running. Dojo {defectdojo_url} Topic {zap_topic} Project {gcp_project}")
 
     parser = argparse.ArgumentParser(description="Get scan types to run")
     parser.add_argument(
@@ -174,7 +174,7 @@ def main():
     scan_types = set(ScanType[s.upper()] for s in args.scans)
     logging.info(f"Scan types: { args.scans }")
 
-    endpoints = get_defect_dojo_endpoints(defect_dojo_url, defect_dojo_key)
+    endpoints = get_defect_dojo_endpoints(defectdojo_url, defect_dojo_key)
     logging.info(f"Defect Dojo {len(endpoints) if endpoints else 'no'} endpoints fetched.")
 
     trigger_scans(endpoints, gcp_project, zap_topic, scan_types)

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -48,6 +48,7 @@ def zap_sa_auth(zap: ZAPv2, env):
     logging.info("Authenticating via Replacer...")
     token = get_gcp_token()
     bearer = f"Bearer {token}"
+    success = False
     zap.replacer.add_rule(
         description="auth",
         enabled=True,
@@ -56,8 +57,9 @@ def zap_sa_auth(zap: ZAPv2, env):
         matchstring="Authorization",
         replacement=bearer,
     )
-    if not terra_auth.terra_is_registered(token, env):
-        success = terra_auth.terra_register_sa(token, env)
+    # checks to see if the user is logged in, registered,
+    # and has signed the TOS.
+    success = terra_auth.terra_register_sa(token, env)
     if success:
         logging.info("ZAP Service Account is registered with Terra.")
     else:

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -66,7 +66,7 @@ def zap_sa_auth(zap: ZAPv2, env):
         logging.info("ZAP Service Account failed to register with Terra")
         return
     terra_auth.terra_tos(token, env)
-    
+
 
 
 def zap_api_import(zap: ZAPv2, target_url: str):
@@ -77,7 +77,6 @@ def zap_api_import(zap: ZAPv2, target_url: str):
     res = zap.openapi.import_url(target_url)
     if zap.core.urls() == start_urls:
         raise RuntimeError(f"Failed to import API from {target_url}: {res}")
-    
 
 
 def get_gcp_token() -> str:
@@ -134,9 +133,9 @@ def zap_save_session(zap: ZAPv2, project: str, scan_type: ScanType):
     share_path_sess = share_path+"/session/"
     session_filename = f"{project}_{scan_type}-session"
     session_filename = session_filename.replace("-", "_").replace(" ", "")
-    #zap scanner container saves session to shared volume
+    # zap scanner container saves session to shared volume
     zap.core.save_session(share_path_sess+session_filename)
-    #scan controller uses same shared volume to zip session and return the filename
+    # scan controller uses same shared volume to zip session and return the filename
     try:
         shutil.make_archive(session_filename, 'zip' , share_path_sess)
     except BaseException as base_error: # pylint: disable=bare-except
@@ -159,7 +158,7 @@ def zap_compliance_scan(
     if "dev" in target_url:
         env = "dev"
     # ToDo ZAP scans should be run in a context. This provides a scope for the scan,
-    # and can provide more granular authentication controls. 
+    # and can provide more granular authentication controls.
 
     # Scan types:
     # BASELINE - unauthenticated, no active scan.

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -59,15 +59,16 @@ def zap_sa_auth(zap: ZAPv2, env):
     )
     # checks to see if the user is logged in, registered,
     # and has signed the TOS.
-    success = terra_auth.terra_register_sa(token, env)
+    success = terra_auth.terra_register_sa(bearer, env)
     if success:
         logging.info("ZAP Service Account is registered with Terra.")
+        tos = terra_auth.terra_tos(bearer, env)
+        if tos:
+            logging.info("SA has accepted the TOS.")
     else:
         logging.info("ZAP Service Account failed to register with Terra.")
         return
-    tos = terra_auth.terra_tos(token, env)
-    if tos:
-        logging.info("SA has accepted the TOS.")
+    
 
 
 

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -35,7 +35,7 @@ def zap_init(zap_port: int, target_url: str):
     zap = zap_connect(zap_port)
     zap.core.new_session(name='zap_session', overwrite=True)
     logging.info("Accessing target %s", target_url)
-    # ToDo replace with api call to core.accessUrl
+    # replace with api call to core.accessUrl
     zap_access_target(zap, target_url)
 
     return zap
@@ -63,9 +63,11 @@ def zap_sa_auth(zap: ZAPv2, env):
     if success:
         logging.info("ZAP Service Account is registered with Terra.")
     else:
-        logging.info("ZAP Service Account failed to register with Terra")
+        logging.info("ZAP Service Account failed to register with Terra.")
         return
-    terra_auth.terra_tos(token, env)
+    tos = terra_auth.terra_tos(token, env)
+    if tos:
+        logging.info("SA has accepted the TOS.")
 
 
 
@@ -157,7 +159,7 @@ def zap_compliance_scan(
     env = "prod" #set prod as default
     if "dev" in target_url:
         env = "dev"
-    # ToDo ZAP scans should be run in a context. This provides a scope for the scan,
+    # ZAP scans should be run in a context. This provides a scope for the scan,
     # and can provide more granular authentication controls.
 
     # Scan types:


### PR DESCRIPTION
The first step to being able to scan Leo apps in azure is to ensure that the service account being used is registered and has accepted the TOS. 
Because we scan in both dev and prod, it selects which environment to register with based on the url of the service being scanned. 
Checking this every scan due to it being low overhead and ensures that the scan is run with a registered and TOS accepting user.
![Screenshot 2023-05-24 at 11 15 36 AM](https://github.com/broadinstitute/dsp-appsec-infrastructure-apps/assets/93540258/aa7a68de-6ecf-46ea-a5b8-08158cf31d5c)