### PR TITLE
roll back dojo version

### DIFF
--- a/bastion/Dockerfile
+++ b/bastion/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM us.gcr.io/broad-dsp-gcr-public/base/nodejs:alpine AS base
 
 RUN apk add --no-cache dante-server
 

--- a/batch/Dockerfile
+++ b/batch/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/base/python:alpine AS base
+FROM us.gcr.io/broad-dsp-gcr-public/base/nodejs:alpine AS base
 
 COPY requirements.txt .
 

--- a/batch/Dockerfile
+++ b/batch/Dockerfile
@@ -1,4 +1,4 @@
-FROM us.gcr.io/broad-dsp-gcr-public/base/nodejs:alpine AS base
+FROM us.gcr.io/broad-dsp-gcr-public/base/python:alpine AS base
 
 COPY requirements.txt .
 

--- a/defectdojo/Dockerfile.django
+++ b/defectdojo/Dockerfile.django
@@ -1,4 +1,4 @@
-FROM defectdojo/defectdojo-django:2.22.2 as dd
+FROM defectdojo/defectdojo-django:2.21.2 as dd
 
 FROM dd as patch
 

--- a/defectdojo/Dockerfile.django
+++ b/defectdojo/Dockerfile.django
@@ -1,4 +1,4 @@
-FROM defectdojo/defectdojo-django:2.22.3 as dd
+FROM defectdojo/defectdojo-django:2.22.2 as dd
 
 FROM dd as patch
 

--- a/defectdojo/Dockerfile.django
+++ b/defectdojo/Dockerfile.django
@@ -1,4 +1,4 @@
-FROM defectdojo/defectdojo-django as dd
+FROM defectdojo/defectdojo-django:2.22.3 as dd
 
 FROM dd as patch
 

--- a/defectdojo/Dockerfile.django
+++ b/defectdojo/Dockerfile.django
@@ -1,4 +1,4 @@
-FROM defectdojo/defectdojo-django:2.21.2 as dd
+FROM defectdojo/defectdojo-django:2.21.1 as dd
 
 FROM dd as patch
 


### PR DESCRIPTION
Rolls back dojo version to 2.21.1
This version includes the UI fix for closing old findings product wide, but does not include the bug that was introduced in 2.22.0. The bug causes most findings on import to close, leaving only one or two open. It is not clear why only a couple are left open, but it is clear that findings that are still present should not be closed.