### PR TITLE
[DSEC-672] Update dojo and remove banner

### DIFF
--- a/defectdojo/Dockerfile.django
+++ b/defectdojo/Dockerfile.django
@@ -1,4 +1,4 @@
-FROM defectdojo/defectdojo-django:2.21.1 as dd
+FROM defectdojo/defectdojo-django:2.23.1 as dd
 
 FROM dd as patch
 

--- a/sdarq/frontend/src/app/form/form.component.html
+++ b/sdarq/frontend/src/app/form/form.component.html
@@ -1,9 +1,6 @@
 <div class="jumbotron min-vh-100">
   <div class="container">
     <div class="row">
-      <div class="alert alert-danger animated fadeInRight" role="alert">
-        <p>Hello, New Service questionnaire is currently unavailable. We apologize for the inconvenience and are working to fix it as quickly as we can. Thank you! </p>
-      </div>
     <div class="alert alert-danger animated fadeInRight" role="alert" *ngIf="showAlert">
       <h4 class="alert-heading">Oops!</h4>
       <p>{{errors}}</p>


### PR DESCRIPTION
Updates DefectDojo to latest release which contains the fix for the import findings bug we were experiencing. 
Removes the banner advertising that new product isn't working in SDARQ.

Tested creating a new product as well as importing findings. 