### PR TITLE
[DSEC-652] add tag to query string in trigger.py

### DIFF
--- a/zap/src/trigger.py
+++ b/zap/src/trigger.py
@@ -34,7 +34,9 @@ def get_defect_dojo_endpoints(base_url: str, api_key: str) -> List[Endpoint]:
     """
     Fetch endpoints from DefectDojo.
     """
-    endpoint = base_url + "/api/v2/endpoints?limit=1000"
+    # Fetch endpoints that have been tagged with scan:*
+    # It is unlikely that there are more than 1000 of them
+    endpoint = base_url + "/api/v2/endpoints?limit=1000&tag=scan"
     headers = {
         "content-type": "application/json",
         "Authorization": f"Token {api_key}",


### PR DESCRIPTION
Terra prod was being skipped on the monthly runs due to page limits of the query fetching tagged endpoints from dojo. Added more search terms to the query to limit the number of endpoints returned. 