### PR TITLE
make product creation more robust

### DIFF
--- a/batch/Dockerfile
+++ b/batch/Dockerfile
@@ -2,6 +2,8 @@ FROM us.gcr.io/broad-dsp-gcr-public/base/python:alpine AS base
 
 COPY requirements.txt .
 
+RUN pip3 install --upgrade pip
+RUN pip install "Cython<3.0" pyyaml --no-build-isolation
 RUN pip3 install -r requirements.txt
 
 FROM base AS test

--- a/sdarq/backend/src/app.py
+++ b/sdarq/backend/src/app.py
@@ -191,6 +191,7 @@ def submit():
 
         logging.info("Jira tickets in AppSec board are created")
 
+        #
         setSecConDDlink = db.collection(security_controls_firestore_collection).document(
             dojo_name.lower())
         doc = setSecConDDlink.get()
@@ -263,7 +264,7 @@ def submit_app():
 
         del json_data['Ticket_Description']
 
-        dojo_helper.dojo_create_or_update(dojo_name, parse_json_data.prepare_dojo_input(json_data), product_type, user_email)
+        product_id = dojo_helper.dojo_create_or_update(dojo_name, parse_json_data.prepare_dojo_input(json_data), product_type, user_email)
 
         slacknotify.slacknotify_app_jira(
             appsec_slack_channel,

--- a/sdarq/backend/src/app.py
+++ b/sdarq/backend/src/app.py
@@ -156,7 +156,8 @@ def submit():
 
         del json_data['Ticket_Description']
 
-        dojo_helper.dojo_create_or_update(dojo_name, parse_json_data.prepare_dojo_input(json_data), product_type, user_email)
+
+        product_id = dojo_helper.dojo_create_or_update(dojo_name, parse_json_data.prepare_dojo_input(json_data), product_type, user_email)
 
         slacknotify.slacknotify_jira(
             appsec_slack_channel,

--- a/sdarq/backend/src/app.py
+++ b/sdarq/backend/src/app.py
@@ -126,7 +126,6 @@ def submit():
         dojo_name = json_data['Service']
         security_champion = json_data['Security champion']
         product_type = 1
-        products_endpoint = f"{dojo_host}api/v2/products/"
         user_email = request.headers.get('X-Goog-Authenticated-User-Email')
 
         architecture_diagram = json_data['Architecture Diagram']
@@ -233,7 +232,6 @@ def submit_app():
         dojo_name = json_data['Service']
         security_champion = json_data['Security champion']
         product_type = 1
-        products_endpoint = f"{dojo_host}api/v2/products/"
         user_email = request.headers.get('X-Goog-Authenticated-User-Email')
 
         architecture_diagram = json_data['Architecture Diagram']

--- a/sdarq/backend/src/dojo_helper.py
+++ b/sdarq/backend/src/dojo_helper.py
@@ -23,7 +23,8 @@ def dojo_create_or_update(name, description, product_type, user_email):
     if response.json()['count'] > 0:
         id = response.json()['results'][0]['id']
         data['description'] = data['description'] + " updated by " + user_email
-        res = requests.patch(products_endpoint+"/"+str(id),headers=headers, data=json.dumps(data))
+        logging.info(data)
+        res = requests.patch(products_endpoint+"/"+str(id), headers=headers, data=data)
         if res.status_code != 200:
             logging.info("failed to update product")
             logging.info(res.text)

--- a/sdarq/backend/src/dojo_helper.py
+++ b/sdarq/backend/src/dojo_helper.py
@@ -24,7 +24,7 @@ def dojo_create_or_update(name, description, product_type, user_email):
         id = response.json()['results'][0]['id']
         data['description'] = data['description'] + " updated by " + user_email
         logging.info(data)
-        res = requests.patch(products_endpoint+"/"+str(id), headers=headers, data=data)
+        res = requests.patch(products_endpoint + str(id) + "/", headers=headers, data=data)
         if res.status_code != 200:
             logging.info("failed to update product")
             logging.info(res.text)

--- a/sdarq/backend/src/dojo_helper.py
+++ b/sdarq/backend/src/dojo_helper.py
@@ -24,7 +24,7 @@ def dojo_create_or_update(name, description, product_type, user_email):
         product_id = response.json()['results'][0]['id']
         data['description'] = data['description'] + " updated by " + user_email
         logging.info(data)
-        res = requests.patch(products_endpoint + str(product_id) + "/", headers=headers, data=data)
+        res = requests.patch(products_endpoint + str(product_id) + "/", headers=headers, data=json.dumps(data))
         if res.status_code != 200:
             logging.info("failed to update product")
             logging.info(res.text)

--- a/sdarq/backend/src/dojo_helper.py
+++ b/sdarq/backend/src/dojo_helper.py
@@ -22,7 +22,7 @@ def dojo_create_or_update(name, description, product_type, user_email):
     response = requests.get(products_endpoint+"?name_exact="+name, headers=headers)
     if response.json()['count'] > 0:
         id = response.json()['results'][0]['id']
-        res = requests.patch(products_endpoint+"/"+id, data=json.dump(data))
+        res = requests.patch(products_endpoint+"/"+id, data=json.dumps(data))
         logging.info("Product updated: %s by %s request",
                         name, user_email)
         return id

--- a/sdarq/backend/src/dojo_helper.py
+++ b/sdarq/backend/src/dojo_helper.py
@@ -24,7 +24,11 @@ def dojo_create_or_update(name, description, product_type, user_email):
         id = response.json()['results'][0]['id']
         data['description'] = data['description'] + " updated by " + user_email
         res = requests.patch(products_endpoint+"/"+str(id),headers=headers, data=json.dumps(data))
-        logging.info("Product updated: %s by %s request",
+        if res.status_code != 200:
+            logging.info("failed to update product")
+            logging.info(res.text)
+        else:
+            logging.info("Product updated: %s by %s request",
                         name, user_email)
         return id
     else:

--- a/sdarq/backend/src/dojo_helper.py
+++ b/sdarq/backend/src/dojo_helper.py
@@ -22,7 +22,7 @@ def dojo_create_or_update(name, description, product_type, user_email):
     response = requests.get(products_endpoint+"?name_exact="+name, headers=headers)
     if response.json()['count'] > 0:
         id = response.json()['results'][0]['id']
-        res = requests.patch(products_endpoint+"/"+id, data=json.dumps(data))
+        res = requests.patch(products_endpoint+"/"+str(id), data=json.dumps(data))
         logging.info("Product updated: %s by %s request",
                         name, user_email)
         return id

--- a/sdarq/backend/src/dojo_helper.py
+++ b/sdarq/backend/src/dojo_helper.py
@@ -23,15 +23,12 @@ def dojo_create_or_update(name, description, product_type, user_email):
     if response.json()['count'] > 0:
         product_id = response.json()['results'][0]['id']
         data['description'] = data['description'] + " updated by " + user_email
-        logging.info(data)
         res = requests.patch(products_endpoint + str(product_id) + "/", headers=headers, data=json.dumps(data))
         if res.status_code != 200:
             logging.info("failed to update product")
-            logging.info(res.text)
         else:
             logging.info("Product updated: %s by %s request",
                         name, user_email)
-            logging.info(res.text)
         return product_id
     else:
         res = requests.post(products_endpoint,

--- a/sdarq/backend/src/dojo_helper.py
+++ b/sdarq/backend/src/dojo_helper.py
@@ -1,0 +1,35 @@
+import json
+import logging
+import os
+
+import requests
+
+dojo_host = os.getenv('dojo_host')
+dojo_api_key = os.getenv('dojo_api_key')
+headers = {
+    "content-type": "application/json",
+    "Authorization": f"Token {dojo_api_key}",
+}
+
+
+products_endpoint = f"{dojo_host}api/v2/products/"
+
+def dojo_create_or_update(name, description, product_type, user_email):
+    data = {
+        'name': name,
+        'description': description,
+        'prod_type': product_type}
+    response = requests.get(products_endpoint+"?name_exact="+name, headers=headers)
+    if response.json()['count'] > 0:
+        id = response.json()['results'][0]['id']
+        res = requests.patch(products_endpoint+"/"+id, data=json.dump(data))
+        logging.info("Product updated: %s by %s request",
+                        name, user_email)
+    else:
+        res = requests.post(products_endpoint,
+                                headers=headers, data=json.dumps(data))
+        res.raise_for_status()
+        product_id = res.json()['id']
+
+        logging.info("Product created: %s by %s request",
+                        name, user_email)

--- a/sdarq/backend/src/dojo_helper.py
+++ b/sdarq/backend/src/dojo_helper.py
@@ -22,7 +22,8 @@ def dojo_create_or_update(name, description, product_type, user_email):
     response = requests.get(products_endpoint+"?name_exact="+name, headers=headers)
     if response.json()['count'] > 0:
         id = response.json()['results'][0]['id']
-        res = requests.patch(products_endpoint+"/"+str(id), data=json.dumps(data))
+        data['description'] = data['description'] + " updated by " + user_email
+        res = requests.patch(products_endpoint+"/"+str(id),headers=headers, data=json.dumps(data))
         logging.info("Product updated: %s by %s request",
                         name, user_email)
         return id

--- a/sdarq/backend/src/dojo_helper.py
+++ b/sdarq/backend/src/dojo_helper.py
@@ -21,10 +21,10 @@ def dojo_create_or_update(name, description, product_type, user_email):
         'prod_type': product_type}
     response = requests.get(products_endpoint+"?name_exact="+name, headers=headers)
     if response.json()['count'] > 0:
-        id = response.json()['results'][0]['id']
+        product_id = response.json()['results'][0]['id']
         data['description'] = data['description'] + " updated by " + user_email
         logging.info(data)
-        res = requests.patch(products_endpoint + str(id) + "/", headers=headers, data=data)
+        res = requests.patch(products_endpoint + str(product_id) + "/", headers=headers, data=data)
         if res.status_code != 200:
             logging.info("failed to update product")
             logging.info(res.text)
@@ -32,7 +32,7 @@ def dojo_create_or_update(name, description, product_type, user_email):
             logging.info("Product updated: %s by %s request",
                         name, user_email)
             logging.info(res.text)
-        return id
+        return product_id
     else:
         res = requests.post(products_endpoint,
                                 headers=headers, data=json.dumps(data))

--- a/sdarq/backend/src/dojo_helper.py
+++ b/sdarq/backend/src/dojo_helper.py
@@ -30,6 +30,7 @@ def dojo_create_or_update(name, description, product_type, user_email):
         else:
             logging.info("Product updated: %s by %s request",
                         name, user_email)
+            logging.info(res.text)
         return id
     else:
         res = requests.post(products_endpoint,

--- a/sdarq/backend/src/dojo_helper.py
+++ b/sdarq/backend/src/dojo_helper.py
@@ -25,6 +25,7 @@ def dojo_create_or_update(name, description, product_type, user_email):
         res = requests.patch(products_endpoint+"/"+id, data=json.dump(data))
         logging.info("Product updated: %s by %s request",
                         name, user_email)
+        return id
     else:
         res = requests.post(products_endpoint,
                                 headers=headers, data=json.dumps(data))
@@ -33,3 +34,4 @@ def dojo_create_or_update(name, description, product_type, user_email):
 
         logging.info("Product created: %s by %s request",
                         name, user_email)
+        return product_id


### PR DESCRIPTION
Currently if a product already exists in DefectDojo the new product questionnaire fails when you submit it. There are valid scenarios where the product has already been created before the engineering team submits the form, and it would be nice if submitting the form updated the project if it didn't exist. 
This PR moves the call for creating a new dojo project into a helper function, and adds checking to see if the project already exists. If it does, the description is updated with the new information provided in the questionnaire. 