### PR TITLE
[DSEC-654] Add context and cookie auth to zap scans

### DIFF
--- a/zap/deployment.yaml
+++ b/zap/deployment.yaml
@@ -183,7 +183,7 @@ items:
             << : *cron-job-spec
             containers:
             - << : *cron-job-container
-              args: ['trigger', '-s', 'ui']
+              args: ['trigger', '-s', 'ui','leoapp']
 ---
 apiVersion: storage.cnrm.cloud.google.com/v1beta1
 kind: StorageBucket

--- a/zap/src/scan.py
+++ b/zap/src/scan.py
@@ -72,7 +72,7 @@ def defectdojo_upload(product_id: int, zap_filename: str, defect_dojo_key: str, 
     
     try:
         lead_id = dojo.list_users(defect_dojo_user).data["results"][0]["id"]
-    except:
+    except Exception:
         logging.error("Did not retrieve dojo user ID, upload failed.")
         return
 
@@ -281,6 +281,9 @@ def slack_alert_without_report(  # pylint: disable=too-many-arguments
         logging.info("Alert sent to Slack channel for DefectDojo upload report")
 
 def clean_uri_path(xml_report):
+    """
+    Remove the changing hash from the path of static resources in zap report.
+    """
     tree = ET.parse(xml_report)
     root = tree.getroot()
     #There's a hash in bundled files that is causing flaws to not match, this should remove the hash.

--- a/zap/src/scan.py
+++ b/zap/src/scan.py
@@ -16,6 +16,7 @@ from urllib.parse import urlparse, urlunparse
 
 import defectdojo_apiv2 as defectdojo
 import defusedxml.ElementTree as ET
+import requests
 from codedx_api.CodeDxAPI import CodeDx  # pylint: disable=import-error
 from google.cloud import storage
 from slack_sdk.web import WebClient as SlackClient
@@ -30,7 +31,7 @@ def fetch_dojo_product_name(defect_dojo, defect_dojo_user, defect_dojo_key, prod
     dojo = defectdojo.DefectDojoAPIv2(
         defect_dojo, defect_dojo_key, defect_dojo_user, debug=False, timeout=120)
     product = dojo.get_product(product_id=product_id)
-    return product["name"]
+    return product.data["name"]
 
 def upload_gcs(bucket_name: str, scan_type: ScanType, filename: str, subfoldername=None):
     """

--- a/zap/src/scan.py
+++ b/zap/src/scan.py
@@ -354,7 +354,7 @@ def main(): # pylint: disable=too-many-locals
                 s.value for s in severities))
 
             (zap_filename, session_filename) = zap_compliance_scan(
-                dojo_product_name, target_url, scan_type)
+                dojo_product_name, zap_port, target_url, scan_type)
 
             # optionally, upload them to GCS
             xml_report_url = ""

--- a/zap/src/scan.py
+++ b/zap/src/scan.py
@@ -16,7 +16,6 @@ from urllib.parse import urlparse, urlunparse
 
 import defectdojo_apiv2 as defectdojo
 import defusedxml.ElementTree as ET
-import requests
 from codedx_api.CodeDxAPI import CodeDx  # pylint: disable=import-error
 from google.cloud import storage
 from slack_sdk.web import WebClient as SlackClient
@@ -33,6 +32,7 @@ def fetch_dojo_product_name(defect_dojo, defect_dojo_user, defect_dojo_key, prod
     product = dojo.get_product(product_id=product_id)
     return product.data["name"]
 
+
 def upload_gcs(bucket_name: str, scan_type: ScanType, filename: str, subfoldername=None):
     """
     Upload scans to a GCS bucket and return the path to the file in Cloud Console.
@@ -46,7 +46,8 @@ def upload_gcs(bucket_name: str, scan_type: ScanType, filename: str, subfolderna
         path = f"{scan_type}-scans/{date}/{subfoldername}/{filename}"
     blob = bucket.blob(path)
     blob.upload_from_filename(filename)
-    return f"https://console.cloud.google.com/storage/browser/_details/{bucket_name}/{path}"        
+    return f"https://console.cloud.google.com/storage/browser/_details/{bucket_name}/{path}"
+
 
 def error_slack_alert(error: str, token: str, channel: str):
     """
@@ -79,7 +80,7 @@ def defectdojo_upload(product_id: int, zap_filename: str, defect_dojo_key: str, 
 
     absolute_path = os.path.abspath(zap_filename)
     date = datetime.today().strftime("%Y%m%d%H:%M")
-    
+
     try:
         lead_id = dojo.list_users(defect_dojo_user).data["results"][0]["id"]
     except Exception:

--- a/zap/src/scan.py
+++ b/zap/src/scan.py
@@ -354,7 +354,7 @@ def main(): # pylint: disable=too-many-locals
                 s.value for s in severities))
 
             (zap_filename, session_filename) = zap_compliance_scan(
-                dojo_product_name, zap_port, target_url, scan_type)
+                dojo_product_name, target_url, scan_type)
 
             # optionally, upload them to GCS
             xml_report_url = ""

--- a/zap/src/terra_auth.py
+++ b/zap/src/terra_auth.py
@@ -20,6 +20,7 @@ def terra_is_registered(token, env):
     resp = requests.request(
         "GET",
         url + "register/user/v2/self/termsOfServiceComplianceStatus",
+        timeout=5,
         headers={
             "Authorization": token
         })
@@ -58,6 +59,7 @@ def terra_register_sa(token, env):
         resp = requests.request(
         "POST",
         url,
+        timeout=5,
         headers={
             "Authorization": token,
             "Content-Type": "application/json"
@@ -82,6 +84,7 @@ def terra_auth_logged_in(token, env):
     resp = requests.request(
         "GET",
         url,
+        timeout=5,
         headers={
             "Authorization": token
         }
@@ -106,6 +109,7 @@ def terra_tos(token, env):
     resp = requests.request(
         "POST",
         url,
+        timeout=5,
         headers={
             "Authorization": token,
             "Content-Type": "application/json"

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -18,7 +18,7 @@ from zapv2 import ZAPv2
 
 TIMEOUT_MINS = 5
 
-zap_port = int(os.getenv("ZAP_PORT", ""))
+zap_port = int(os.getenv("ZAP_PORT"))
 proxy = f"http://localhost:{zap_port}"
 
 

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -99,12 +99,16 @@ def leo_auth(host, path, token):
         target_dir = path_parts[1]
     else:
         # Leo endpoint is /proxy//setCookie
+        logging.info("Using the default proxy directory for setCookie")
         target_dir = "proxy"
+    logging.info("Using the setCookie endpoint to set the cookie.")
     set_cookie_endpoint = f"https://{host}/{target_dir}//setCookie"
     headers = {"Authorization": token}
     response = requests.get(set_cookie_endpoint, headers=headers, timeout=10)
-    if response.status_code == 200:
+    if response.status_code == 204:
+        logging.info("Set cookie was successful")
         return True
+    logging.info("Set cookie did not succeed")
     return False
 
 def zap_setup_cookie(zap, domain, context_id):
@@ -113,6 +117,7 @@ def zap_setup_cookie(zap, domain, context_id):
     This can be done within a context.
     """
     # Copied from dsp-appsec-zap-automation
+    logging.info("Set up test user in context: " + context_id)
     username = "testuser"
     zap.users.new_user(context_id, username)
     userid = zap.users.users_list(context_id)[0]["id"]

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -70,8 +70,7 @@ def zap_sa_auth(zap: ZAPv2, env, target):
         matchtype="REQ_HEADER",
         matchregex=False,
         matchstring="Authorization",
-        replacement=bearer,
-        url=target + ".*"
+        replacement=bearer
     )
     # checks to see if the user is logged in, registered,
     # and has signed the TOS.

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -80,12 +80,12 @@ def zap_setup_context(zap, project, host, zap_port):
                 zap.context.include_in_context(project, config_json[key] + ".*")
     except Exception:
         # If there's no config.json, return.
-        return context_id
+        logging.info("No config.json found")
 
     return context_id
 
 
-def zap_sa_auth(zap: ZAPv2, env, target):
+def zap_sa_auth(zap: ZAPv2, env):
     """
     Set up Google token auth for ZAP requests.
     """

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -131,7 +131,7 @@ def zap_setup_cookie(zap, domain, context_id):
     # This is the secret sauce for using cookies.
     # The user above is now associated with the active cookie.
     # It should always choose the newest one.
-    sessions=zap.httpsessions.sessions(site = domain)
+    sessions=zap.httpsessions.sessions(site = domain+":443")
     session_name=sessions[-1]["session"][0]
     zap.users.set_authentication_credentials(context_id,userid,"sessionName=" + session_name)
 

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -286,7 +286,7 @@ def zap_compliance_scan(
     context_id = zap_setup_context(zap, project, host, zap_port)
 
     if scan_type != ScanType.BASELINE:
-        token = zap_sa_auth(zap, env, target_url)
+        token = zap_sa_auth(zap, env)
         if scan_type == ScanType.LEOAPP:
             success = leo_auth(host, path, token, zap_port)
             if success:

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -108,7 +108,8 @@ def leo_auth(host, path, token, zap_port):
         target_dir = "proxy"
     logging.info("Using the setCookie endpoint to set the cookie.")
     set_cookie_endpoint = f"https://{host}/{target_dir}//setCookie"
-    headers = {"Authorization": token}
+    headers = {"Authorization": token,
+               "Referer":f"https://{host}/"}
     # verify is set to false in order to proxy requests through ZAP
     response = requests.get(set_cookie_endpoint, headers=headers,
                             timeout=25, proxies=proxies, verify=False)

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -109,7 +109,9 @@ def leo_auth(host, path, token, zap_port):
     logging.info("Using the setCookie endpoint to set the cookie.")
     set_cookie_endpoint = f"https://{host}/{target_dir}//setCookie"
     headers = {"Authorization": token}
-    response = requests.get(set_cookie_endpoint, headers=headers, timeout=25, proxies=proxies)
+    # verify is set to false in order to proxy requests through ZAP
+    response = requests.get(set_cookie_endpoint, headers=headers,
+                            timeout=25, proxies=proxies, verify=False)
     if response.status_code == 204:
         logging.info("Set cookie was successful")
         return True

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -104,7 +104,7 @@ def leo_auth(host, path, token):
     logging.info("Using the setCookie endpoint to set the cookie.")
     set_cookie_endpoint = f"https://{host}/{target_dir}//setCookie"
     headers = {"Authorization": token}
-    response = requests.get(set_cookie_endpoint, headers=headers, timeout=10)
+    response = requests.get(set_cookie_endpoint, headers=headers, timeout=25)
     if response.status_code == 204:
         logging.info("Set cookie was successful")
         return True

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -55,7 +55,7 @@ def parse_url(url):
 
     return parsed_hostname, parsed_port, parsed_path
 
-def zap_setup_context(zap, project, host):
+def zap_setup_context(zap, project, host, zap_port):
     """
     Setup context and scope for scan
     """
@@ -278,7 +278,7 @@ def zap_compliance_scan(
     #LEOAPP - authenticated with SA and registered cookie, active scan and ajax spider is performed
     
     # Set up context for scan
-    context_id = zap_setup_context(zap, project, host)
+    context_id = zap_setup_context(zap, project, host, zap_port)
 
     if scan_type != ScanType.BASELINE:
         token = zap_sa_auth(zap, env, target_url)

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -18,24 +18,22 @@ from zapv2 import ZAPv2
 
 TIMEOUT_MINS = 5
 
-zap_port = int(os.getenv("ZAP_PORT"))
-proxy = f"http://localhost:{zap_port}"
 
-
-def zap_connect():
+def zap_connect(zap_port: int):
     """
     Connect to the Zap instance
     """
+    proxy = f"http://localhost:{zap_port}"
     zap = ZAPv2(proxies={"http": proxy, "https": proxy})
     wait_for_zap_start(zap, timeout_in_secs=TIMEOUT_MINS * 60)
     return zap
 
 
-def zap_init(target_url: str):
+def zap_init(zap_port: int, target_url: str):
     """
     Connect to ZAP service running on localhost.
     """
-    zap = zap_connect()
+    zap = zap_connect(zap_port)
     zap.core.new_session(name='zap_session', overwrite=True)
     logging.info("Accessing target %s", target_url)
     # replace with api call to core.accessUrl
@@ -87,14 +85,15 @@ def zap_sa_auth(zap: ZAPv2, env, target):
     return token
 
 
-def leo_auth(host, path, token):
+def leo_auth(host, path, token, zap_port):
     """
     Set up cookie auth for leo apps.
     """
+    proxy = f"http://localhost:{zap_port}"
     proxies = {
-            'http': proxy,
-            'https': proxy,
-            }
+        'http': proxy,
+        'https': proxy,
+        }
     logging.info("Authenticating to Leo...")
     # Leo apps if already launched have a separate domain from Leo.
     # And there's a workspace id after the host. https://custom.host/workspaceId/apiEndPoints
@@ -218,6 +217,7 @@ def zap_save_session(zap: ZAPv2, project: str, scan_type: ScanType):
 
 def zap_compliance_scan(
     project: str,
+    zap_port: int,
     target_url: str,
     scan_type: ScanType = ScanType.BASELINE,
 ):
@@ -227,7 +227,7 @@ def zap_compliance_scan(
 
     host, _, path = parse_url(target_url)
 
-    zap = zap_init(target_url)
+    zap = zap_init(zap_port, target_url)
     env = "prod" #set prod as default
     if "dev" in host:
         env = "dev"

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -251,7 +251,7 @@ def zap_compliance_scan(
     if scan_type != ScanType.BASELINE:
         token = zap_sa_auth(zap, env, target_url)
         if scan_type == ScanType.LEOAPP:
-            leo_auth(host, path, token)
+            leo_auth(host, path, token, zap_port)
             cookie_name = "LeoToken"
             zap.httpsessions.add_default_session_token(cookie_name)
             # Sets a user in the context with the cookie, and forces all Zap requests to use that cookie


### PR DESCRIPTION
This is a little big. It introduces a new scan type, LEOAPP, in order to support azure apps launched by Leo. To support this new type it adds contexts to zap scans and sets cookies for LeoApps. 