### PR TITLE
[DSEC-687][sdarq][backend] Fix Jira ticket creation

### DIFF
--- a/sdarq/backend/src/app.py
+++ b/sdarq/backend/src/app.py
@@ -151,6 +151,14 @@ def submit():
 
         product_id = dojo_helper.dojo_create_or_update(dojo_name, parse_json_data.prepare_dojo_input(json_data), product_type, user_email, appsec_slack_channel, security_champion, dojo_host_url)
 
+        setSecConDDlink = db.collection(security_controls_firestore_collection).document(
+            dojo_name.lower())
+        doc = setSecConDDlink.get()
+        if bool(doc.to_dict()) is True:
+            setSecConDDlink.set({
+                u'defect_dojo': '{0}/product/{1}'.format(dojo_host_url, str(product_id))
+            }, merge=True)
+            
         jiranotify.create_board_ticket(
             appsec_jira_project_key,
             app_jira_ticket_summury_alerts,
@@ -179,14 +187,6 @@ def submit():
             formatted_jira_description)
 
         logging.info("Jira ticket in %s board created by %s", project_key_id, user_email)
-
-        setSecConDDlink = db.collection(security_controls_firestore_collection).document(
-            dojo_name.lower())
-        doc = setSecConDDlink.get()
-        if bool(doc.to_dict()) is True:
-            setSecConDDlink.set({
-                u'defect_dojo': '{0}/product/{1}'.format(dojo_host_url, str(product_id))
-            }, merge=True)
 
         return ''
     except Exception as error:

--- a/sdarq/backend/src/app.py
+++ b/sdarq/backend/src/app.py
@@ -253,7 +253,7 @@ def submit_app():
 
         del json_data['Ticket_Description']
 
-        product_id = dojo_helper.dojo_create_or_update(dojo_name, parse_json_data.prepare_dojo_input(json_data), product_type, user_email)
+        product_id = dojo_helper.dojo_create_or_update(dojo_name, parse_json_data.prepare_dojo_input(json_data), product_type, user_email, appsec_slack_channel, security_champion, dojo_host_url, jira_instance, project_key_id, jira_ticket )
 
         slacknotify.slacknotify_app_jira(
             appsec_slack_channel,

--- a/sdarq/backend/src/app.py
+++ b/sdarq/backend/src/app.py
@@ -145,20 +145,11 @@ def submit():
 
         validate(instance=json_data, schema=new_service_schema)
 
-        formatted_jira_description = jira_description.strip(
-            '", "').replace('", "', '\n-')
-
-        jira_ticket = jiranotify.create_board_ticket(
-            project_key_id, dev_jira_ticket_summury_alerts, formatted_jira_description)
-
-        logging.info("Jira ticket in %s board created by %s",
-                     project_key_id, user_email)
+        formatted_jira_description = jira_description.strip('", "').replace('", "', '\n-')
 
         del json_data['Ticket_Description']
 
-
-        product_id = dojo_helper.dojo_create_or_update(dojo_name, parse_json_data.prepare_dojo_input(json_data), product_type, user_email, appsec_slack_channel, security_champion, dojo_host_url, jira_instance, project_key_id, jira_ticket)
-
+        product_id = dojo_helper.dojo_create_or_update(dojo_name, parse_json_data.prepare_dojo_input(json_data), product_type, user_email, appsec_slack_channel, security_champion, dojo_host_url)
 
         jiranotify.create_board_ticket(
             appsec_jira_project_key,
@@ -181,6 +172,13 @@ def submit():
             appsec_jira_ticket_description)
 
         logging.info("Jira tickets in AppSec board are created")
+
+        jiranotify.create_board_ticket(
+            project_key_id,
+            dev_jira_ticket_summury_alerts,
+            formatted_jira_description)
+
+        logging.info("Jira ticket in %s board created by %s", project_key_id, user_email)
 
         setSecConDDlink = db.collection(security_controls_firestore_collection).document(
             dojo_name.lower())
@@ -254,7 +252,7 @@ def submit_app():
 
         del json_data['Ticket_Description']
 
-        product_id = dojo_helper.dojo_create_or_update(dojo_name, parse_json_data.prepare_dojo_input(json_data), product_type, user_email, appsec_slack_channel, security_champion, dojo_host_url, jira_instance, project_key_id, jira_ticket )
+        product_id = dojo_helper.dojo_create_or_update(dojo_name, parse_json_data.prepare_dojo_input(json_data), product_type, user_email, appsec_slack_channel, security_champion, dojo_host_url)
 
         slacknotify.slacknotify_app_jira(
             appsec_slack_channel,

--- a/sdarq/backend/src/app.py
+++ b/sdarq/backend/src/app.py
@@ -179,14 +179,10 @@ def submit():
             appsec_jira_ticket_summury_sast,
             appsec_jira_ticket_description)
 
-        logging.info("Jira tickets in AppSec board are created")
-
         jiranotify.create_board_ticket(
             project_key_id,
             dev_jira_ticket_summury_alerts,
             formatted_jira_description)
-
-        logging.info("Jira ticket in %s board created by %s", project_key_id, user_email)
 
         return ''
     except Exception as error:
@@ -276,15 +272,10 @@ def submit_app():
             appsec_jira_ticket_summury_sast,
             appsec_jira_ticket_description)
 
-        logging.info("Jira tickets in AppSec board created")
-
         jiranotify.create_board_ticket(
             project_key_id,
             dev_jira_ticket_summury_alerts,
             formatted_jira_description)
-
-        logging.info("Jira ticket in %s board created by %s",
-                     project_key_id, user_email)
 
         return ''
     except Exception as error:

--- a/sdarq/backend/src/app.py
+++ b/sdarq/backend/src/app.py
@@ -158,7 +158,7 @@ def submit():
             setSecConDDlink.set({
                 u'defect_dojo': '{0}/product/{1}'.format(dojo_host_url, str(product_id))
             }, merge=True)
-            
+
         jiranotify.create_board_ticket(
             appsec_jira_project_key,
             app_jira_ticket_summury_alerts,
@@ -244,25 +244,17 @@ def submit_app():
         formatted_jira_description = jira_description.strip(
             '", "').replace('", "', '\n-')
 
-        jira_ticket = jiranotify.create_board_ticket(
-            project_key_id, dev_jira_ticket_summury_alerts, formatted_jira_description)
-
-        logging.info("Jira ticket in %s board created by %s",
-                     project_key_id, user_email)
-
         del json_data['Ticket_Description']
 
         product_id = dojo_helper.dojo_create_or_update(dojo_name, parse_json_data.prepare_dojo_input(json_data), product_type, user_email, appsec_slack_channel, security_champion, dojo_host_url)
 
-        slacknotify.slacknotify_app_jira(
-            appsec_slack_channel,
-            dojo_name,
-            security_champion,
-            product_id,
-            dojo_host_url,
-            jira_instance,
-            project_key_id,
-            jira_ticket)
+        setSecConDDlink = db.collection(
+            security_controls_firestore_collection).document(dojo_name.lower())
+        doc = setSecConDDlink.get()
+        if bool(doc.to_dict()) is True:
+            setSecConDDlink.set({
+                u'defect_dojo': '{0}/product/{1}'.format(dojo_host_url, str(product_id))
+            }, merge=True)
 
         jiranotify.create_board_ticket(
             appsec_jira_project_key,
@@ -286,13 +278,13 @@ def submit_app():
 
         logging.info("Jira tickets in AppSec board created")
 
-        setSecConDDlink = db.collection(
-            security_controls_firestore_collection).document(dojo_name.lower())
-        doc = setSecConDDlink.get()
-        if bool(doc.to_dict()) is True:
-            setSecConDDlink.set({
-                u'defect_dojo': '{0}/product/{1}'.format(dojo_host_url, str(product_id))
-            }, merge=True)
+        jiranotify.create_board_ticket(
+            project_key_id,
+            dev_jira_ticket_summury_alerts,
+            formatted_jira_description)
+
+        logging.info("Jira ticket in %s board created by %s",
+                     project_key_id, user_email)
 
         return ''
     except Exception as error:

--- a/sdarq/backend/src/dojo_helper.py
+++ b/sdarq/backend/src/dojo_helper.py
@@ -14,7 +14,7 @@ headers = {
 
 products_endpoint = f"{dojo_host}api/v2/products/"
 
-def dojo_create_or_update(name, description, product_type, user_email, appsec_slack_channel, security_champion, dojo_host_url, jira_instance, project_key_id, jira_ticket):
+def dojo_create_or_update(name, description, product_type, user_email, appsec_slack_channel, security_champion, dojo_host_url):
     data = {
         'name': name,
         'description': description,
@@ -35,10 +35,7 @@ def dojo_create_or_update(name, description, product_type, user_email, appsec_sl
             name,
             security_champion,
             product_id,
-            dojo_host_url,
-            jira_instance,
-            project_key_id,
-            jira_ticket)
+            dojo_host_url)
             
         return product_id
     else:
@@ -52,10 +49,7 @@ def dojo_create_or_update(name, description, product_type, user_email, appsec_sl
         name,
         security_champion,
         product_id,
-        dojo_host_url,
-        jira_instance,
-        project_key_id,
-        jira_ticket)
+        dojo_host_url)
 
         logging.info("Product created: %s by %s request",
                         name, user_email)

--- a/sdarq/backend/src/jiranotify.py
+++ b/sdarq/backend/src/jiranotify.py
@@ -1,4 +1,5 @@
 from jira import JIRA
+import logging
 import os
 
 jira_username = os.getenv('jira_username')
@@ -11,10 +12,70 @@ jira = JIRA(basic_auth=(jira_username, jira_api_token),
             options={'server': jira_instance})
 
 
+def create_task_ticket(appsec_jira_project_key, ticket_summary, ticket_description):
+    """
+    This function creates a Jira task ticket
+    Args: 
+        appsec_jira_project_key
+        ticket_summary
+        ticket_description
+    Returns: 
+        Jira Ticket id or None (with an exception)
+    """
+    try:
+        jira_ticket = jira.create_issue(project=appsec_jira_project_key,
+                                        summary=ticket_summary,
+                                        description=str(
+                                            ticket_description),
+                                        issuetype={'name': 'Task'})
+        return jira_ticket
+    except Exception as error:
+        print(f"Jira Task creation failed with error: {error}")
+        logging.warning(error)
+        return None
+    
+
+def create_story_ticket(appsec_jira_project_key, ticket_summary, ticket_description):
+    """
+    This functions creates a Jira story ticket
+    Args: 
+        appsec_jira_project_key
+        ticket_summary
+        ticket_description
+    Returns: 
+        Jira Ticket id or None (with an exception)
+    """
+    try:
+        jira_ticket = jira.create_issue(project=appsec_jira_project_key,
+                                        summary=ticket_summary,
+                                        description=str(
+                                            ticket_description),
+                                        issuetype={'name': 'Story'})
+        return jira_ticket
+    except Exception as error:
+        print(f"Jira Story creation failed with error: {error}")
+        logging.warning(error)
+        return None
+
+
 def create_board_ticket(appsec_jira_project_key, ticket_summary, ticket_description):
-    jira_ticket = jira.create_issue(project=appsec_jira_project_key,
-                                    summary=ticket_summary,
-                                    description=str(
-                                        ticket_description),
-                                    issuetype={'name': 'Task'})
-    return jira_ticket
+    """
+    This fucntion creates a Jira task ticket, if the request is successful return Jira Ticket id,
+    if not, tries to create a Jira story ticket.
+    """
+    task = create_task_ticket(appsec_jira_project_key, ticket_summary, ticket_description)
+    if task is not None:
+        print("Jira Task created successfully!")
+        logging.info("Jira Task created successfully!")
+    else:
+        print("Jira Task creation failed. Creating a story.")
+        logging.info("Jira Task creation failed. Creating a story.")
+
+        story = create_story_ticket(appsec_jira_project_key, ticket_summary, ticket_description)
+        
+        if story is not None:
+            print("Story ticket created successfully!")
+            logging.info("Story ticket created successfully!")
+        else:
+            print("Failed to create a story ticket.")
+            logging.info("Failed to create a story ticket.")

--- a/sdarq/backend/src/jiranotify.py
+++ b/sdarq/backend/src/jiranotify.py
@@ -1,10 +1,13 @@
 from jira import JIRA
 import logging
+import slacknotify
 import os
 
 jira_username = os.getenv('jira_username')
 jira_api_token = os.getenv('jira_api_token')
 jira_instance = os.getenv('jira_instance')
+appsec_sdarq_error_channel = os.getenv('appsec_sdarq_error_channel')
+
 
 
 global jira
@@ -30,9 +33,9 @@ def create_task_ticket(appsec_jira_project_key, ticket_summary, ticket_descripti
                                         issuetype={'name': 'Task'})
         return jira_ticket
     except Exception as error:
-        print(f"Jira Task creation failed with error: {error}")
         logging.warning(error)
-        return error
+        slacknotify.slacknotify_jira_ticket_error(error, appsec_sdarq_error_channel, appsec_jira_project_key)
+        return None
     
 
 def create_story_ticket(appsec_jira_project_key, ticket_summary, ticket_description):
@@ -53,9 +56,9 @@ def create_story_ticket(appsec_jira_project_key, ticket_summary, ticket_descript
                                         issuetype={'name': 'Story'})
         return jira_ticket
     except Exception as error:
-        print(f"Jira Story creation failed with error: {error}")
         logging.warning(error)
-        return error
+        slacknotify.slacknotify_jira_ticket_error(error, appsec_sdarq_error_channel, appsec_jira_project_key)
+        return None
 
 
 def create_board_ticket(appsec_jira_project_key, ticket_summary, ticket_description):
@@ -65,17 +68,13 @@ def create_board_ticket(appsec_jira_project_key, ticket_summary, ticket_descript
     """
     task = create_task_ticket(appsec_jira_project_key, ticket_summary, ticket_description)
     if task is not None:
-        print("Jira Task created successfully!")
         logging.info("Jira Task created successfully!")
     else:
-        print("Jira Task creation failed. Creating a story.")
         logging.info("Jira Task creation failed. Creating a story.")
 
         story = create_story_ticket(appsec_jira_project_key, ticket_summary, ticket_description)
         
         if story is not None:
-            print("Story ticket created successfully!")
             logging.info("Story ticket created successfully!")
         else:
-            print("Failed to create a story ticket.")
             logging.info("Failed to create a story ticket.")

--- a/sdarq/backend/src/jiranotify.py
+++ b/sdarq/backend/src/jiranotify.py
@@ -20,7 +20,7 @@ def create_task_ticket(appsec_jira_project_key, ticket_summary, ticket_descripti
         ticket_summary
         ticket_description
     Returns: 
-        Jira Ticket id or None (with an exception)
+        Jira Ticket id
     """
     try:
         jira_ticket = jira.create_issue(project=appsec_jira_project_key,
@@ -32,7 +32,7 @@ def create_task_ticket(appsec_jira_project_key, ticket_summary, ticket_descripti
     except Exception as error:
         print(f"Jira Task creation failed with error: {error}")
         logging.warning(error)
-        return None
+        return error
     
 
 def create_story_ticket(appsec_jira_project_key, ticket_summary, ticket_description):
@@ -43,7 +43,7 @@ def create_story_ticket(appsec_jira_project_key, ticket_summary, ticket_descript
         ticket_summary
         ticket_description
     Returns: 
-        Jira Ticket id or None (with an exception)
+        Jira Ticket id
     """
     try:
         jira_ticket = jira.create_issue(project=appsec_jira_project_key,
@@ -55,7 +55,7 @@ def create_story_ticket(appsec_jira_project_key, ticket_summary, ticket_descript
     except Exception as error:
         print(f"Jira Story creation failed with error: {error}")
         logging.warning(error)
-        return None
+        return error
 
 
 def create_board_ticket(appsec_jira_project_key, ticket_summary, ticket_description):

--- a/sdarq/backend/src/slacknotify.py
+++ b/sdarq/backend/src/slacknotify.py
@@ -390,3 +390,37 @@ def slacknotify_error_submit_endpoint(error_message, appsec_sdarq_error_channel,
         ], "color": "#bd3022"}]
     )
 
+
+def slacknotify_jira_ticket_error(error, appsec_sdarq_error_channel, appsec_jira_project_key):
+    """
+    Sends Slack notifications to AppSec when there is an error happening in submit endpoint
+
+    Args:
+        appsec_slack_channel: AppSec Slack channel 
+        user_email: Dev email that completed the form
+        error: Exception message 
+        dojo_name: Service name
+
+    Returns:
+        Sends slack notification
+    """
+    client.chat_postMessage(
+        channel=appsec_sdarq_error_channel,
+        text="Error happened for ticket creation",
+        attachments=[{"blocks":[
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "*Error:* `{0}` " .format(str(error))
+                }
+            },           
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": "*JIra Board:* `{0}` " .format(str(appsec_jira_project_key))
+                }
+            }
+        ], "color": "#bd3022"}]
+    )

--- a/sdarq/backend/src/slacknotify.py
+++ b/sdarq/backend/src/slacknotify.py
@@ -19,7 +19,6 @@ def slacknotify_app_jira(appsec_slack_channel, dojo_name, security_champion, pro
     """
     Sends slack notification when there is:
         1. New app 
-        2. Jira ticket is selected 
 
     Args:
         appsec_slack_channel: Slack channel name
@@ -27,9 +26,6 @@ def slacknotify_app_jira(appsec_slack_channel, dojo_name, security_champion, pro
         security_champion: Security champion name
         product_id: Product in defectdojo
         dojo_host: DefectDojo host
-        jira_instance:  Jira Cloud instance
-        project_key_id: Jira project id
-        jira_ticket: Jira ticket path 
 
     Returns:
         Sends slack notification
@@ -79,9 +75,6 @@ def slacknotify_jira(appsec_slack_channel, dojo_name, security_champion, product
         security_champion: Security champion name
         product_id: Product in defectdojo
         dojo_host: DefectDojo host
-        jira_instance:  Jira Cloud instance
-        project_key_id: Jira project id
-        jira_ticket: Jira ticket path 
 
     Returns:
         Sends slack notification
@@ -120,7 +113,7 @@ def slacknotify_jira(appsec_slack_channel, dojo_name, security_champion, product
         ], "color": "#0731b0"}]
     )
 
-def slacknotify_updateprod_jira(appsec_slack_channel, dojo_name, security_champion, product_id, dojo_host_url, jira_instance, project_key_id, jira_ticket):
+def slacknotify_updateprod_jira(appsec_slack_channel, dojo_name, security_champion, product_id, dojo_host_url):
     """
     Sends slack notification when there is: 
         1. Existing service updated
@@ -131,9 +124,6 @@ def slacknotify_updateprod_jira(appsec_slack_channel, dojo_name, security_champi
         security_champion: Security champion name
         product_id: Product in defectdojo
         dojo_host: DefectDojo host
-        jira_instance:  Jira Cloud instance
-        project_key_id: Jira project id
-        jira_ticket: Jira ticket path 
 
     Returns:
         Sends slack notification
@@ -166,14 +156,6 @@ def slacknotify_updateprod_jira(appsec_slack_channel, dojo_name, security_champi
                             "text": "Defect Dojo"
                         },
                         "url": "{0}/product/{1}" .format(dojo_host_url, str(product_id))
-                    },
-                    {
-                        "type": "button",
-                        "text": {
-                            "type": "plain_text",
-                            "text": "Jira Ticket"
-                        },
-                        "url": "{0}/projects/{1}/issues/{2}" .format(jira_instance, str(project_key_id), str(jira_ticket))
                     }
                 ]
             }
@@ -382,7 +364,7 @@ def slacknotify_error_submit_endpoint(error_message, appsec_sdarq_error_channel,
     """
     client.chat_postMessage(
         channel=appsec_sdarq_error_channel,
-        text="Error happened for new service endpoint",
+        text="Error happened for new service/ new app endpoint",
         attachments=[{"blocks":[
             {
                 "type": "section",

--- a/sdarq/backend/src/slacknotify.py
+++ b/sdarq/backend/src/slacknotify.py
@@ -15,7 +15,7 @@ client = WebClient(token=slack_token,
                          ssl=ssl_context)
 
 
-def slacknotify_app_jira(appsec_slack_channel, dojo_name, security_champion, product_id, dojo_host_url, jira_instance, project_key_id, jira_ticket):
+def slacknotify_app_jira(appsec_slack_channel, dojo_name, security_champion, product_id, dojo_host_url):
     """
     Sends slack notification when there is:
         1. New app 
@@ -62,21 +62,13 @@ def slacknotify_app_jira(appsec_slack_channel, dojo_name, security_champion, pro
                             "text": "Defect Dojo"
                         },
                         "url": "{0}/product/{1}" .format(dojo_host_url, str(product_id))
-                    },
-                    {
-                        "type": "button",
-                        "text": {
-                            "type": "plain_text",
-                            "text": "Jira Ticket"
-                        },
-                        "url": "{0}/projects/{1}/issues/{2}" .format(jira_instance, str(project_key_id), str(jira_ticket))
                     }
                 ]
             }
         ], "color": "#0731b0"}]
     )
 
-def slacknotify_jira(appsec_slack_channel, dojo_name, security_champion, product_id, dojo_host_url, jira_instance, project_key_id, jira_ticket):
+def slacknotify_jira(appsec_slack_channel, dojo_name, security_champion, product_id, dojo_host_url):
     """
     Sends slack notification when there is: 
         1. New service
@@ -122,14 +114,6 @@ def slacknotify_jira(appsec_slack_channel, dojo_name, security_champion, product
                             "text": "Defect Dojo"
                         },
                         "url": "{0}/product/{1}" .format(dojo_host_url, str(product_id))
-                    },
-                    {
-                        "type": "button",
-                        "text": {
-                            "type": "plain_text",
-                            "text": "Jira Ticket"
-                        },
-                        "url": "{0}/projects/{1}/issues/{2}" .format(jira_instance, str(project_key_id), str(jira_ticket))
                     }
                 ]
             }


### PR DESCRIPTION
This PR:

- Creates DefectDojo product even if the dev team Jira ticket is not created successfully
- Extends `jiranotify` file to create a Jira task ticket and if it fails it tries to create a Jira story ticket
- Removes the Jira ticket link in the Slack notification
- If there are exceptions, they are reported to a Slack channel
