### PR TITLE
refactor scan type

### DIFF
--- a/zap/src/scan.py
+++ b/zap/src/scan.py
@@ -318,8 +318,6 @@ def main(): # pylint: disable=too-many-locals
         # run Zap scan
         try:
             # parse env variables
-            zap_port = int(getenv("ZAP_PORT", ""))
-
             codedx_project = getenv("CODEDX_PROJECT")
             codedx_url = getenv("CODEDX_URL")
             codedx_api_key = getenv("CODEDX_API_KEY")
@@ -355,7 +353,7 @@ def main(): # pylint: disable=too-many-locals
                 s.value for s in severities))
 
             (zap_filename, session_filename) = zap_compliance_scan(
-                dojo_product_name, zap_port, target_url, scan_type)
+                dojo_product_name, target_url, scan_type)
 
             # optionally, upload them to GCS
             xml_report_url = ""
@@ -418,7 +416,7 @@ def main(): # pylint: disable=too-many-locals
                 )
 
 
-            zap = zap_connect(zap_port)
+            zap = zap_connect()
             zap.core.shutdown()
         except Exception as error: # pylint: disable=broad-except
             error_message = f"[RETRY-{ attempt }] Exception running Zap Scans: { error }"
@@ -427,7 +425,7 @@ def main(): # pylint: disable=too-many-locals
                 error_message = f"Error running Zap Scans for { target_url }. Last known error: { error }"
                 error_slack_alert(error_message, slack_token, slack_channel)
                 try:
-                    zap = zap_connect(zap_port)
+                    zap = zap_connect()
                     zap.core.shutdown()
                 except Exception as zap_e: # pylint: disable=broad-except
                     error_message = f"Error shutting down zap: { zap_e }"

--- a/zap/src/trigger.py
+++ b/zap/src/trigger.py
@@ -14,8 +14,7 @@ from typing import List, Literal, Optional, Set, TypedDict
 
 import requests
 from google.cloud.pubsub_v1 import PublisherClient
-
-from zap import ScanType
+from zap_scan_type import ScanType
 
 
 class Endpoint(TypedDict):  # pylint: disable=inherit-non-class,too-few-public-methods

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -60,7 +60,7 @@ def parse_url(url):
     return parsed_hostname, parsed_port, parsed_path
 
 
-def zap_setup_context(zap, project, host, zap_port):
+def zap_setup_context(zap, project, host):
     """
     Setup context and scope for scan
     """

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -14,26 +14,29 @@ import terra_auth
 from google.auth.transport.requests import Request as GoogleAuthRequest
 from zap_common import (wait_for_zap_start, write_report, zap_access_target,
                         zap_wait_for_passive_scan)
+from zap_scan_type import ScanType
 from zapv2 import ZAPv2
 
 TIMEOUT_MINS = 5
 
+zap_port = int(os.getenv("ZAP_PORT", ""))
+proxy = f"http://localhost:{zap_port}"
 
-def zap_connect(zap_port: int):
+
+def zap_connect():
     """
     Connect to the Zap instance
     """
-    proxy = f"http://localhost:{zap_port}"
     zap = ZAPv2(proxies={"http": proxy, "https": proxy})
     wait_for_zap_start(zap, timeout_in_secs=TIMEOUT_MINS * 60)
     return zap
 
 
-def zap_init(zap_port: int, target_url: str):
+def zap_init(target_url: str):
     """
     Connect to ZAP service running on localhost.
     """
-    zap = zap_connect(zap_port)
+    zap = zap_connect()
     zap.core.new_session(name='zap_session', overwrite=True)
     logging.info("Accessing target %s", target_url)
     # replace with api call to core.accessUrl
@@ -61,26 +64,13 @@ def zap_setup_context(zap, project, host, zap_port):
     """
     Setup context and scope for scan
     """
-    proxy = f"http://localhost:{zap_port}"
-    proxies = {
-        'http': proxy,
-        'https': proxy,
-        }
 
     zap.context.new_context(project)
     context_id = zap.context.context(project)["id"]
     zap.authentication.set_authentication_method(context_id, "manualAuthentication")
 
     zap.context.include_in_context(project, ".*" + host + ".*")
-    resp = requests.get(f"https://{host}/config.json", proxies=proxies, verify=False)
-    try:
-        config_json = resp.json()
-        for key in config_json:
-            if "Root" in key:
-                zap.context.include_in_context(project, config_json[key] + ".*")
-    except Exception:
-        # If there's no config.json, return.
-        logging.info("No config.json found")
+    
 
     return context_id
 
@@ -114,17 +104,16 @@ def zap_sa_auth(zap: ZAPv2, env):
     return token
 
 
-def leo_auth(host, path, token, zap_port):
+def leo_auth(host, path, token):
     """
     Set up cookie auth for leo apps.
     """
-    proxy = f"http://localhost:{zap_port}"
     proxies = {
         'http': proxy,
         'https': proxy,
         }
 
-    zap = zap_connect(zap_port)
+    zap = zap_connect()
     zap.httpsessions.add_default_session_token("LeoToken")
     logging.info("Authenticating to Leo...")
     # Leo apps if already launched have a separate domain from Leo.
@@ -203,23 +192,7 @@ def get_gcp_token() -> str:
     return credentials.token
 
 
-class ScanType(str, Enum):
-    """
-    Enumerates Zap compliance scan types
-    """
 
-    API = "API"
-    AUTH = "Authenticated"
-    BASELINE = "Baseline"
-    UI = "UI"
-    LEOAPP = "LeoApp"
-
-    def __str__(self):
-        return str(self.name).lower()
-
-    def label(self):
-        """"Get user-friendly name of the scan type"""
-        return str(self.value)
 
 
 def zap_report(zap: ZAPv2, project: str, scan_type: ScanType):
@@ -258,7 +231,6 @@ def zap_save_session(zap: ZAPv2,
 
 def zap_compliance_scan(
     project: str,
-    zap_port: int,
     target_url: str,
     scan_type: ScanType = ScanType.BASELINE,
 ):
@@ -268,7 +240,7 @@ def zap_compliance_scan(
 
     host, _, path = parse_url(target_url)
 
-    zap = zap_init(zap_port, target_url)
+    zap = zap_init(target_url)
     env = "prod"  # set prod as default
     if "dev" in host:
         env = "dev"
@@ -283,12 +255,12 @@ def zap_compliance_scan(
     # LEOAPP - authenticated with SA and registered cookie, active scan and ajax spider is performed
 
     # Set up context for scan
-    context_id = zap_setup_context(zap, project, host, zap_port)
+    context_id = zap_setup_context(zap, project, host)
 
     if scan_type != ScanType.BASELINE:
         token = zap_sa_auth(zap, env)
         if scan_type == ScanType.LEOAPP:
-            success = leo_auth(host, path, token, zap_port)
+            success = leo_auth(host, path, token)
             if success:
                 # Sets a user in the context with the cookie,
                 # and forces all Zap requests to use that cookie

--- a/zap/src/zap_scan_type.py
+++ b/zap/src/zap_scan_type.py
@@ -1,0 +1,24 @@
+"""
+Provides the ScanType Enum.
+"""
+
+from enum import Enum
+
+
+class ScanType(str, Enum):
+    """
+    Enumerates Zap compliance scan types
+    """
+
+    API = "API"
+    AUTH = "Authenticated"
+    BASELINE = "Baseline"
+    UI = "UI"
+    LEOAPP = "LeoApp"
+
+    def __str__(self):
+        return str(self.name).lower()
+
+    def label(self):
+        """"Get user-friendly name of the scan type"""
+        return str(self.value)


### PR DESCRIPTION
Puts the scan type enum into its own file, allowing for globals with environment variables in the zap.py file. (This was previously blocked by trigger.py importing zap.py without having the correct env vars available.) 