### PR TITLE
[cis] Use Broadinstitute fork for GKE benchmark

### DIFF
--- a/cis/Dockerfile
+++ b/cis/Dockerfile
@@ -52,7 +52,6 @@ RUN pylint --disable=W0702,W0613,E0611,C0301,E1101,R0913,W1309,C0209 /*.py
 RUN pytest /entrypoint_test.py
 
 
-
 FROM base
 
 ARG USER

--- a/cis/Dockerfile
+++ b/cis/Dockerfile
@@ -18,6 +18,8 @@ RUN apt-get update && \
     pip3 install -Ur requirements.txt \
     && \
     gem install inspec-bin -qN && \
+    # Remove patching if this PR is merged:
+    # https://github.com/inspec/inspec/pull/6155
     cd /var/lib/gems/*/gems/inspec-core-*/ && \
     patch -N -p1 < /inspec_ruby_3.1.patch && \
     cd / && \

--- a/cis/Dockerfile
+++ b/cis/Dockerfile
@@ -6,7 +6,7 @@ ARG USER
 
 ENV CHEF_LICENSE="accept-no-persist"
 
-COPY requirements.txt .
+COPY requirements.txt inspec_ruby_3.1.patch /
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -18,6 +18,11 @@ RUN apt-get update && \
     pip3 install -Ur requirements.txt \
     && \
     gem install inspec-bin -qN && \
+    # Remove patching if this PR is merged:
+    # https://github.com/inspec/inspec/pull/6155
+    cd /var/lib/gems/*/gems/inspec-core-*/ && \
+    patch -N -p1 < /inspec_ruby_3.1.patch && \
+    cd / && \
     git clone --depth 1 https://github.com/GoogleCloudPlatform/inspec-gcp-cis-benchmark.git && \
     git clone --depth 1 https://github.com/broadinstitute/inspec-gke-cis-benchmark.git && \
     mv inspec-gke-cis-benchmark/inspec-gke-cis-gcp . && \

--- a/cis/Dockerfile
+++ b/cis/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
     && \
     gem install inspec-bin -qN && \
     git clone --depth 1 https://github.com/GoogleCloudPlatform/inspec-gcp-cis-benchmark.git && \
-    git clone --depth 1 https://github.com/GoogleCloudPlatform/inspec-gke-cis-benchmark.git && \
+    git clone --depth 1 https://github.com/broadinstitute/inspec-gke-cis-benchmark.git && \
     mv inspec-gke-cis-benchmark/inspec-gke-cis-gcp . && \
     mv inspec-gke-cis-benchmark/inspec-gke-cis-k8s . \
     && \

--- a/cis/Dockerfile
+++ b/cis/Dockerfile
@@ -18,8 +18,6 @@ RUN apt-get update && \
     pip3 install -Ur requirements.txt \
     && \
     gem install inspec-bin -qN && \
-    # Remove patching if this PR is merged:
-    # https://github.com/inspec/inspec/pull/6155
     cd /var/lib/gems/*/gems/inspec-core-*/ && \
     patch -N -p1 < /inspec_ruby_3.1.patch && \
     cd / && \

--- a/cis/Dockerfile
+++ b/cis/Dockerfile
@@ -41,7 +41,6 @@ RUN apt-get update && \
     chown "${USER}" .inspec inspec-*-cis-*
 
 
-
 FROM base AS test
 
 RUN pip3 install -U pylint pytest

--- a/cis/Dockerfile
+++ b/cis/Dockerfile
@@ -41,6 +41,7 @@ RUN apt-get update && \
     chown "${USER}" .inspec inspec-*-cis-*
 
 
+
 FROM base AS test
 
 RUN pip3 install -U pylint pytest

--- a/cis/entrypoint.py
+++ b/cis/entrypoint.py
@@ -25,7 +25,6 @@ BENCHMARK_PROFILES = (
     'inspec-gke-cis-k8s',
 )
 
-
 def benchmark(target_project_id: str, profile: str):
     """
     Runs a Google Cloud Inspec CIS benchmark profile

--- a/cis/inspec_ruby_3.1.patch
+++ b/cis/inspec_ruby_3.1.patch
@@ -1,0 +1,49 @@
+From cc5346f780d08b76aa7493062ed25127bf5c8b16 Mon Sep 17 00:00:00 2001
+From: Robert Clark <robert.clark@kirkpatrickprice.com>
+Date: Mon, 20 Jun 2022 15:12:16 -0400
+Subject: [PATCH] Properly split args and kwargs for Ruby 3.x when loading
+ resources.
+
+By default, InSpec calls super on defined resources automatically. On Ruby 3.x this is broken since args and kwargs are handled differently. This fixes the problem by properly splitting out the parameters. Fixes #6154 https://github.com/GoogleCloudPlatform/inspec-gcp-helpers/issues/12
+
+Signed-off-by: Robert Clark <robert.clark@kirkpatrickprice.com>
+---
+ lib/inspec/profile_context.rb | 4 ++--
+ lib/inspec/resource.rb        | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/lib/inspec/profile_context.rb b/lib/inspec/profile_context.rb
+index a479736d3d..17b40daaa0 100644
+--- a/lib/inspec/profile_context.rb
++++ b/lib/inspec/profile_context.rb
+@@ -253,11 +253,11 @@ def add_registry_methods(profile_context)
+ 
+           registry = profile_context.resource_registry
+           registry.each do |id, r|
+-            define_method(id) { |*args| r.new(be, id.to_s, *args) }
++            define_method(id) { |*args, **kwargs| r.new(be, id.to_s, *args, **kwargs) }
+ 
+             next if be.respond_to?(id)
+ 
+-            bec.define_method(id) { |*args| r.new(be, id.to_s, *args) }
++            bec.define_method(id) { |*args, **kwargs| r.new(be, id.to_s, *args, **kwargs) }
+           end
+         end # add_resource_methods
+       end # ClassMethods
+diff --git a/lib/inspec/resource.rb b/lib/inspec/resource.rb
+index 253c710e89..c695e5bd90 100644
+--- a/lib/inspec/resource.rb
++++ b/lib/inspec/resource.rb
+@@ -121,10 +121,10 @@ def self.__register(name, resource_klass)
+         # initialize methods from having to call super, which is,
+         # quite frankly, dumb. Avoidable even with some simple
+         # documentation.
+-        def initialize(backend, name, *args)
++        def initialize(backend, name, *args, **kwargs)
+           supersuper_initialize(backend, name) do
+             @resource_params = args
+-            super(*args)
++            super(*args, **kwargs)
+           end
+         end
+       end


### PR DESCRIPTION
Fixing Inspec incompatibilities due to Ruby 3.1 version upgrade in the latest base blessed image
