### PR TITLE
[DSEC-699] CIS scanner weekkly only for prod projects

### DIFF
--- a/cis/deployment.yaml
+++ b/cis/deployment.yaml
@@ -28,8 +28,6 @@ data:
             value: ${CIS_DATASET}
           - name: CIS_CONTROLS_IGNORE
             value: ${CIS_CONTROLS_IGNORE}
-          - name: CIS_PROD_PROJECTS
-            value: ${CIS_PROD_PROJECTS}
           - name: SLACK_TOKEN
             valueFrom:
               secretKeyRef:
@@ -142,6 +140,8 @@ spec:
                 value: ${PROJECT_ID}
               - name: BQ_DATASET
                 value: ${CIS_DATASET}
+              - name: CIS_PROD_PROJECTS
+                value: ${CIS_PROD_PROJECTS}
               - name: JOB_TOPIC
                 value: ${JOB_TOPIC}
               - name: SLACK_CHANNEL_WEEKLY_REPORT

--- a/cis/deployment.yaml
+++ b/cis/deployment.yaml
@@ -28,6 +28,8 @@ data:
             value: ${CIS_DATASET}
           - name: CIS_CONTROLS_IGNORE
             value: ${CIS_CONTROLS_IGNORE}
+          - name: CIS_PROD_PROJECTS
+            value: ${CIS_PROD_PROJECTS}
           - name: SLACK_TOKEN
             valueFrom:
               secretKeyRef:

--- a/cis/entrypoint.py
+++ b/cis/entrypoint.py
@@ -224,8 +224,6 @@ def main():
     fs_collection = os.getenv('FIRESTORE_COLLECTION')
     cis_controls_ignore_list = os.getenv('CIS_CONTROLS_IGNORE', '')
     cis_controls_ignore_final_list = cis_controls_ignore_list.split(",")
-    cis_prod_projects_list = os.getenv('CIS_PROD_PROJECTS', '')
-    cis_prod_projects_list_final_list = cis_prod_projects_list.split(",")
 
     try:
         # define table_id and Firestore doc_ref for reporting success/errors
@@ -242,7 +240,7 @@ def main():
         load_bigquery(target_project_id, dataset_id, table_id, title, rows)
 
         # post to Slack, if specified
-        if slack_token and slack_channel and slack_results_url and target_project_id in cis_prod_projects_list_final_list:
+        if slack_token and slack_channel and slack_results_url:
             slacknotifications.slack_notify(target_project_id, slack_token,
                          slack_channel, slack_results_url)
             find_highs(rows, slack_channel, slack_token, target_project_id)

--- a/cis/entrypoint.py
+++ b/cis/entrypoint.py
@@ -224,6 +224,8 @@ def main():
     fs_collection = os.getenv('FIRESTORE_COLLECTION')
     cis_controls_ignore_list = os.getenv('CIS_CONTROLS_IGNORE', '')
     cis_controls_ignore_final_list = cis_controls_ignore_list.split(",")
+    cis_prod_projects_list = os.getenv('CIS_PROD_PROJECTS', '')
+    cis_prod_projects_list_final_list = cis_prod_projects_list.split(",")
 
     try:
         # define table_id and Firestore doc_ref for reporting success/errors
@@ -240,7 +242,7 @@ def main():
         load_bigquery(target_project_id, dataset_id, table_id, title, rows)
 
         # post to Slack, if specified
-        if slack_token and slack_channel and slack_results_url:
+        if slack_token and slack_channel and slack_results_url and target_project_id in cis_prod_projects_list_final_list:
             slacknotifications.slack_notify(target_project_id, slack_token,
                          slack_channel, slack_results_url)
             find_highs(rows, slack_channel, slack_token, target_project_id)

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,6 +4,7 @@ substitutions:
   _DNS_DOMAIN: '' # fully-resolved DNS domain name (e.g. appsec.example.org)
   _DNS_ZONE: '' # DNS zone name to be created/updated (e.g. appsec)
   _CIS_CONTROLS_IGNORE: '' # CIS controls rule to ignore
+  _CIS_PROD_PROJECTS: '' # CIS prod projects
   _SECURITY_CONTROLS_IGNORE: '' # Security controls set to false ignore for some services
   _SONAR_ORGS: '' # in-scope SonarCloud organizations
   _CODACY_ORGS: '' # in-scope Codacy organizations
@@ -216,6 +217,7 @@ steps:
   dir: cis
   env:
   - CIS_CONTROLS_IGNORE=${_CIS_CONTROLS_IGNORE}
+  - CIS_PROD_PROJECTS=${_CIS_PROD_PROJECTS}
 
 # deploy CodeDx to GKE cluster
 - id: codedx


### PR DESCRIPTION
This PR:
- Will allow CIS scanner to run weekly only against prod projects

Added a variable in the trigger with all prod projects, the name is `_CIS_PROD_PROJECTS`, and we can add or remove the prod projects just by editing the value of that variable.