### PR TITLE
[DSEC-734] update zap image location

### DIFF
--- a/sdarq/backend/Dockerfile
+++ b/sdarq/backend/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update -q && \
 
 RUN pip3 install -U pytest
 
-COPY --from=owasp/zap2docker-weekly /zap/zap_common.py ./
+COPY --from=softwaresecurityproject/zap-stable /zap/zap_common.py ./
 COPY sdarq/backend/src/schemas/*py ./schemas/
 COPY sdarq/backend/src/*.py zap/src/*.py ./
 COPY sdarq/backend/src/tests/test_app.py ./

--- a/zap/Dockerfile
+++ b/zap/Dockerfile
@@ -1,4 +1,4 @@
-FROM owasp/zap2docker-weekly AS zap
+FROM softwaresecurityproject/zap-stable AS zap
 
 FROM us.gcr.io/broad-dsp-gcr-public/base/python:3.10-debian AS base
 

--- a/zap/deployment.yaml
+++ b/zap/deployment.yaml
@@ -19,7 +19,7 @@ data:
 
         containers:
         - name: zap
-          image: owasp/zap2docker-weekly
+          image: softwaresecurityproject/zap-stable
           volumeMounts:
             - name: shared-data
               mountPath: ${VOLUME_SHARE}


### PR DESCRIPTION
ZAP is no longer an OWASP project, and the docker image location has changed. Updating to the new image location. 

A test scan was requested from SDARQ and a monthly scan was also run manually. 