### PR TITLE
[DSEC-750][CIS] Change version

### DIFF
--- a/cis/Dockerfile
+++ b/cis/Dockerfile
@@ -17,9 +17,7 @@ RUN apt-get update && \
     && \
     pip3 install -Ur requirements.txt \
     && \
-    gem install inspec-bin -qN && \
-    # Remove patching if this PR is merged:
-    # https://github.com/inspec/inspec/pull/6155
+    gem install inspec-bin -v 5.22.29 -qN && \
     cd /var/lib/gems/*/gems/inspec-core-*/ && \
     patch -N -p1 < /inspec_ruby_3.1.patch && \
     cd / && \


### PR DESCRIPTION
This PR:
- Installs a specific version of `inspec-bin` to run CIS Scanner