### PR TITLE
[ZAP Scanner] Update dependencies

### DIFF
--- a/zap/requirements.txt
+++ b/zap/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.8.6
+aiohttp==3.9.0
 codedx-api @ git+https://github.com/broadinstitute/dsp-appsec-codedx-api-client-python.git@cf0de6fcdd0a4db98f2c2a35bd9d2ae7e8056d6b
 google-auth==1.30.0
 google-cloud-pubsub==2.5.0


### PR DESCRIPTION
This PR:

- Updates `aiohttp` dependency to `3.9.0`