### PR TITLE
[DSEC-759] Add scope to report download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 *.bak
-
 *cache*/
 zap/.python-version
+.vscode/
+.vscode/settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
   "python.analysis.extraPaths": ["zap/src"],
   "[python]": {
     "editor.codeActionsOnSave": {
-      "source.organizeImports": true
+      "source.organizeImports": "explicit"
     }
   }
 }

--- a/zap/deployment.yaml
+++ b/zap/deployment.yaml
@@ -24,23 +24,24 @@ data:
             - name: shared-data
               mountPath: ${VOLUME_SHARE}
           command: ['zap.sh']
-          args: [
-            '-daemon',
-            '-host', '127.0.0.1',
-            '-port', '${ZAP_PORT}',
-            '-config', 'api.key=$ZAP_API_KEY',
-            '-config', 'api.filexfer=true',
-            '-Xmx10g',
-          ]
-          resources:
-            requests:
-              memory: 10Gi
           env:
           - name: ZAP_API_KEY
             valueFrom:
               secretKeyRef:
                 name: ${JOB_SECRET}
                 key: ZAP_API_KEY
+          args: [
+            '-daemon',
+            '-host', '127.0.0.1',
+            '-port', '${ZAP_PORT}',
+            '-config', 'api.key=$(ZAP_API_KEY)',
+            '-config', 'api.filexfer=true',
+            '-Xmx10g',
+          ]
+          resources:
+            requests:
+              memory: 10Gi
+          
 
         - name: zap-scan
           image: ${ZAP_IMAGE}

--- a/zap/deployment.yaml
+++ b/zap/deployment.yaml
@@ -196,7 +196,7 @@ items:
             << : *cron-job-spec
             containers:
             - << : *cron-job-container
-              args: ['trigger', '-s', 'ui','leoapp']
+              args: ['trigger', '-s', 'ui']
 ---
 apiVersion: storage.cnrm.cloud.google.com/v1beta1
 kind: StorageBucket

--- a/zap/deployment.yaml
+++ b/zap/deployment.yaml
@@ -28,12 +28,19 @@ data:
             '-daemon',
             '-host', '127.0.0.1',
             '-port', '${ZAP_PORT}',
-            '-config', 'api.disablekey=true',
+            '-config', 'api.key=$ZAP_API_KEY',
+            '-config', 'api.filexfer=true',
             '-Xmx10g',
           ]
           resources:
             requests:
               memory: 10Gi
+          env:
+          - name: ZAP_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: ${JOB_SECRET}
+                key: ZAP_API_KEY
 
         - name: zap-scan
           image: ${ZAP_IMAGE}
@@ -70,6 +77,11 @@ data:
               secretKeyRef:
                 name: ${JOB_SECRET}
                 key: DEFECT_DOJO_USER
+          - name: ZAP_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: ${JOB_SECRET}
+                key: ZAP_API_KEY
           - name: DEFECT_DOJO
             valueFrom:
               secretKeyRef:

--- a/zap/requirements.txt
+++ b/zap/requirements.txt
@@ -3,8 +3,8 @@ codedx-api @ git+https://github.com/broadinstitute/dsp-appsec-codedx-api-client-
 google-auth==1.30.0
 google-cloud-pubsub==2.5.0
 google-cloud-storage==1.38.0
-python-owasp-zap-v2.4==0.0.18
 requests==2.31.0
 slack-sdk==3.5.1
 defusedxml==0.7.1
 pytz
+zaproxy==0.2.0

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -207,14 +207,14 @@ def zap_report(zap: ZAPv2, project: str, scan_type: ScanType, sites: str):
 
     filename = f"{project}_{scan_type}-scan_report.xml"
     filename = filename.replace("-", "_").replace(" ", "")
-    # write_report(filename, zap.core.xmlreport())
 
     template = "traditional-xml"
     report_dir = "/home/zap/.ZAP"
     # logging.info("Pulling report with following arguements: title : "+site+", template : "+template+", contexts : "+context+", sites : "+url)
     # The sites parameter can take several urls separated with '|'.
     # Adding further sites to scope could be done by concatenating them before passing them to this function.
-    zap.reports.generate(title=project, reportfilename=filename, template=template, contexts=project, sites=sites, reportdir= report_dir)
+    return_message = zap.reports.generate(title=project, reportfilename=filename, template=template, contexts=project, sites=sites, reportdir= report_dir)
+    logging.info(return_message)
     # If successful we now have a report sitting in the transfer directory of the zap container
     report_data = zap.core.file_download(filename)
     report_file = open(filename, "w")

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -209,7 +209,7 @@ def zap_report(zap: ZAPv2, project: str, scan_type: ScanType, sites: str):
     filename = filename.replace("-", "_").replace(" ", "")
 
     template = "traditional-xml"
-    report_dir = "/home/zap/.ZAP"
+    report_dir = "/home/zap/.ZAP/transfer"
     # logging.info("Pulling report with following arguements: title : "+site+", template : "+template+", contexts : "+context+", sites : "+url)
     # The sites parameter can take several urls separated with '|'.
     # Adding further sites to scope could be done by concatenating them before passing them to this function.

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -195,7 +195,7 @@ def get_gcp_token() -> str:
 
 
 
-def zap_report(zap: ZAPv2, project: str, scan_type: ScanType):
+def zap_report(zap: ZAPv2, project: str, scan_type: ScanType, sites: str):
     """
     Generate ZAP scan XML report.
     """
@@ -212,7 +212,9 @@ def zap_report(zap: ZAPv2, project: str, scan_type: ScanType):
     template = "traditional-xml"
     reportDir = "/home/zap/.ZAP"
     # logging.info("Pulling report with following arguements: title : "+site+", template : "+template+", contexts : "+context+", sites : "+url)
-    returnmessage = zap.reports.generate(title=project, reportfilename=filename, template=template, contexts=project, reportdir= reportDir)
+    # The sites parameter can take several urls separated with '|'.
+    # Adding further sites to scope could be done by concatenating them before passing them to this function.
+    returnmessage = zap.reports.generate(title=project, reportfilename=filename, template=template, contexts=project, sites=sites, reportdir= reportDir)
     # If successful we now have a report sitting in the transfer directory of the zap container
     report_data = zap.core.file_download(filename)
     report_file = open(filename, "w")
@@ -296,7 +298,7 @@ def zap_compliance_scan(
 
     reportFile = zapscan.localPullReport(zap, project, "https://" + domain, site_name, os.getenv("REPORT_DIR"))
 
-    filename = zap_report(zap, project, scan_type)
+    filename = zap_report(zap, project, scan_type, f"https://{host}")
     session_file = zap_save_session(zap, project, scan_type)
 
     return (filename, session_file)

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -210,11 +210,11 @@ def zap_report(zap: ZAPv2, project: str, scan_type: ScanType, sites: str):
     # write_report(filename, zap.core.xmlreport())
 
     template = "traditional-xml"
-    reportDir = "/home/zap/.ZAP"
+    report_dir = "/home/zap/.ZAP"
     # logging.info("Pulling report with following arguements: title : "+site+", template : "+template+", contexts : "+context+", sites : "+url)
     # The sites parameter can take several urls separated with '|'.
     # Adding further sites to scope could be done by concatenating them before passing them to this function.
-    returnmessage = zap.reports.generate(title=project, reportfilename=filename, template=template, contexts=project, sites=sites, reportdir= reportDir)
+    zap.reports.generate(title=project, reportfilename=filename, template=template, contexts=project, sites=sites, reportdir= report_dir)
     # If successful we now have a report sitting in the transfer directory of the zap container
     report_data = zap.core.file_download(filename)
     report_file = open(filename, "w")
@@ -296,7 +296,7 @@ def zap_compliance_scan(
     if scan_type != ScanType.BASELINE:
         zap.ascan.scan(target_url, contextid=context_id, recurse=True)
 
-    reportFile = zapscan.localPullReport(zap, project, "https://" + domain, site_name, os.getenv("REPORT_DIR"))
+    # reportFile = zapscan.localPullReport(zap, project, "https://" + domain, site_name, os.getenv("REPORT_DIR"))
 
     filename = zap_report(zap, project, scan_type, f"https://{host}")
     session_file = zap_save_session(zap, project, scan_type)


### PR DESCRIPTION
Changes to ZAP report download to allow for scope. The previous version of report generation would report all findings independent of the intended scope of the scan. The new version restricts findings to those sites that are provided to the zap_report() function.