### PR TITLE
[ZAP] Move API scans to monthly scans

### DIFF
--- a/zap/deployment.yaml
+++ b/zap/deployment.yaml
@@ -172,7 +172,7 @@ items:
             - &cron-job-container
               name: zap-trigger
               image: ${ZAP_IMAGE}
-              args: ['trigger', '-s', 'api', 'auth', 'ui']
+              args: ['trigger', '-s', 'auth', 'ui']
               env:
               - name: GCP_PROJECT_ID
                 value: ${PROJECT_ID}
@@ -193,6 +193,20 @@ items:
               resources:
                 requests:
                   memory: 50Mi
+- << : *cron-job
+  metadata:
+    name: ${CRON_JOB}-monthly
+    namespace: ${NAMESPACE}
+  spec:
+    schedule: "0 0 1 * *"
+    jobTemplate:
+      spec:
+        template:
+          spec:
+            << : *cron-job-spec
+            containers:
+            - << : *cron-job-container
+              args: ['trigger', '-s', 'api']
 
 ---
 apiVersion: storage.cnrm.cloud.google.com/v1beta1

--- a/zap/deployment.yaml
+++ b/zap/deployment.yaml
@@ -172,7 +172,7 @@ items:
             - &cron-job-container
               name: zap-trigger
               image: ${ZAP_IMAGE}
-              args: ['trigger', '-s', 'auth', 'ui']
+              args: ['trigger', '-s', 'ui']
               env:
               - name: GCP_PROJECT_ID
                 value: ${PROJECT_ID}
@@ -206,7 +206,7 @@ items:
             << : *cron-job-spec
             containers:
             - << : *cron-job-container
-              args: ['trigger', '-s', 'api']
+              args: ['trigger', '-s', 'auth', 'api']
 
 ---
 apiVersion: storage.cnrm.cloud.google.com/v1beta1


### PR DESCRIPTION
This PR:

- Moves `API` tag endpoint scans to monthly scans since there's no Compliance requirement for it.  