### PR TITLE
[DSEC-818] GCR to GAR migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,3 @@ Tools integrated with SDARQ:
 `appsec@broadinstitute.org`
 
 
-

--- a/README.md
+++ b/README.md
@@ -19,3 +19,5 @@ Tools integrated with SDARQ:
 ### Questions
 `appsec@broadinstitute.org`
 
+
+

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -316,6 +316,7 @@ resource "google_project_iam_custom_role" "cnrm_sa" {
   title       = "AppSec Apps Config Connector"
   description = "Grants access to manage GCP resources via GKE Config Connector in ${var.cluster_name} cluster"
   permissions = [
+    "artifactregistry.repositories.downloadArtifacts",
     "bigquery.datasets.get",
     "bigquery.datasets.create",
     "bigquery.datasets.update",

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -317,7 +317,6 @@ resource "google_project_iam_custom_role" "cnrm_sa" {
   title       = "AppSec Apps Config Connector"
   description = "Grants access to manage GCP resources via GKE Config Connector in ${var.cluster_name} cluster"
   permissions = [
-    "artifactregistry.repositories.downloadArtifacts",
     "bigquery.datasets.get",
     "bigquery.datasets.create",
     "bigquery.datasets.update",

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -131,6 +131,7 @@ module "node_sa" {
     "roles/logging.logWriter",
     "roles/monitoring.metricWriter",
     "roles/monitoring.viewer",
+    "roles/artifactregistry.reader"
   ]
 }
 


### PR DESCRIPTION
This PR:
- Adds permissions to GKE cluster node Service Account, so nodes can pull images from Google Artifact Registry after migration from GCR