### PR TITLE
[DSEC-888] Add support for IAP authentication

### DIFF
--- a/zap/deployment.yaml
+++ b/zap/deployment.yaml
@@ -103,6 +103,11 @@ data:
               secretKeyRef:
                 name: ${JOB_SECRET}
                 key: SLACK_TOKEN
+          - name: IAP_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                name: ${JOB_SECRET}
+                key: IAP_CLIENT_ID
           - name: CODEDX_PROJECT
             valueFrom:
               fieldRef:

--- a/zap/deployment.yaml
+++ b/zap/deployment.yaml
@@ -177,7 +177,7 @@ items:
             - &cron-job-container
               name: zap-trigger
               image: ${ZAP_IMAGE}
-              args: ['trigger', '-s', 'ui']
+              args: ['trigger', '-s', 'ui', 'iapui']
               env:
               - name: GCP_PROJECT_ID
                 value: ${PROJECT_ID}
@@ -211,7 +211,7 @@ items:
             << : *cron-job-spec
             containers:
             - << : *cron-job-container
-              args: ['trigger', '-s', 'auth', 'api']
+              args: ['trigger', '-s', 'auth', 'api', 'iapapi']
 
 ---
 apiVersion: storage.cnrm.cloud.google.com/v1beta1

--- a/zap/src/scan.py
+++ b/zap/src/scan.py
@@ -393,7 +393,7 @@ def main(): # pylint: disable=too-many-locals
 
             # optionally, upload them to GCS
             xml_report_url = ""
-            if scan_type in (ScanType.UI, ScanType.LEOAPP):
+            if scan_type in (ScanType.UI, ScanType.LEOAPP, ScanType.IAPUI):
                 xml_report_url = upload_gcs(
                     bucket_name,
                     scan_type,
@@ -411,7 +411,7 @@ def main(): # pylint: disable=too-many-locals
             clean_uri_path(zap_filename)
 
             #upload scrubbed results in case we need to do a manual upload
-            if scan_type in (ScanType.UI, ScanType.LEOAPP):
+            if scan_type in (ScanType.UI, ScanType.LEOAPP, ScanType.IAPUI):
                 xml_report_url = upload_gcs(
                     bucket_name,
                     scan_type,
@@ -452,7 +452,7 @@ def main(): # pylint: disable=too-many-locals
                 )
 
             # Upload UI scan XMLs and CodeDx reports to Google Drive.
-            if scan_type in (ScanType.UI, ScanType.LEOAPP):
+            if scan_type in (ScanType.UI, ScanType.LEOAPP, ScanType.IAPUI):
                 try:
                     logging.info('Setting up the google drive API service for uploading reports.')
 

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -168,6 +168,7 @@ def zap_setup_cookie(zap, domain, context_id, cookie_name=None):
         zap.users.set_user_enabled(context_id, userid, True)
         zap.forcedUser.set_forced_user(context_id, userid)
         zap.forcedUser.set_forced_user_mode_enabled(True)
+        zap_access_target(zap, f"https://{domain}")
         return username, userid
     except Exception:
         logging.info("Cookie authenication setup failed.")

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -155,7 +155,7 @@ def zap_setup_cookie(zap, domain, context_id, cookie_name=None):
         userid = zap.users.users_list(context_id)[0]["id"]
         if cookie_name:
             zap.httpsessions.add_default_session_token(cookie_name)
-            zap_access_target(zap, "https://{domain}")
+            zap_access_target(zap, f"https://{domain}")
         # This is the secret sauce for using cookies.
         # The user above is now associated with the active cookie.
         # It should always choose the newest one.
@@ -202,6 +202,7 @@ def zap_set_iap_token(client_id):
     """
     Generate a Google id token for a oath client for the default identity.
     """
+    logging.info("Fetching id token from google.")
     zap = zap_connect()
     open_id_connect_token = id_token.fetch_id_token( GoogleAuthRequest(), 
                                                         client_id)
@@ -314,6 +315,7 @@ def zap_compliance_scan(
             client_id = os.getenv('IAP_CLIENT_ID')
             token = zap_set_iap_token(client_id)
             if scan_type == ScanType.IAPUI:
+                logging.info("Setting beehive session cookie.")
                 cookie_name = "__host-beehive_session"
                 zap_setup_cookie(zap, host, context_id, cookie_name)
         else:

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -114,9 +114,11 @@ def leo_auth(host, path, token):
     zap.httpsessions.add_default_session_token("LeoToken")
     logging.info("Authenticating to Leo...")
     # Leo apps if already launched have a separate domain from Leo.
-    # And there's a workspace id after the host. https://custom.host/workspaceId/apiEndPoints
+    # And there's a workspace id after the host. 
+    # https://custom.host/workspaceId/apiEndPoints
 
-    # Make a request to host/first part of path//setCookie with bearer token header
+    # Make a request to host/first part of path//setCookie 
+    # with bearer token header
     path_parts = path.split('/')
     if len(path_parts) > 1:
         target_dir = path_parts[1]
@@ -158,7 +160,9 @@ def zap_setup_cookie(zap, domain, context_id, cookie_name=None):
     # It should always choose the newest one.
     sessions = zap.httpsessions.sessions(site=domain+":443")
     session_name = sessions[-1]["session"][0]
-    zap.users.set_authentication_credentials(context_id, userid, "sessionName=" + session_name)
+    zap.users.set_authentication_credentials(context_id, 
+                                                userid, 
+                                                "sessionName=" + session_name)
 
     zap.users.set_user_enabled(context_id, userid, True)
     zap.forcedUser.set_forced_user(context_id, userid)
@@ -195,10 +199,9 @@ def zap_set_iap_token(client_id):
     """
     Generate a Google id token for a oath client for the default identity.
     """
-    # client ID needs to come from somewhere. thelma puts it in source code.
-    # need to get google creds first.
     
-    open_id_connect_token = id_token.fetch_id_token( GoogleAuthRequest(), client_id,)
+    open_id_connect_token = id_token.fetch_id_token( GoogleAuthRequest(), 
+                                                        client_id)
     bearer = f"Bearer {open_id_connect_token}"
     zap.replacer.add_rule(
         description="auth",

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -199,7 +199,7 @@ def zap_set_iap_token(client_id):
     """
     Generate a Google id token for a oath client for the default identity.
     """
-    
+    zap = zap_connect()
     open_id_connect_token = id_token.fetch_id_token( GoogleAuthRequest(), 
                                                         client_id)
     bearer = f"Bearer {open_id_connect_token}"

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -311,6 +311,7 @@ def zap_compliance_scan(
             client_id = os.getenv('IAP_CLIENT_ID')
             token = zap_set_iap_token(client_id)
             if scan_type == ScanType.IAPUI:
+                cookie_name = "__host-beehive_session"
                 zap_setup_cookie(zap, host, context_id, cookie_name)
         else:
             token = zap_sa_auth(zap, env)

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -172,7 +172,8 @@ def zap_setup_cookie(zap, domain, context_id, cookie_name=None):
         return username, userid
     except Exception:
         logging.info("Cookie authenication setup failed.")
-        return None,None
+        raise RuntimeError("Failed to set the provided cookie as the default session in Zap.")
+
 
 def zap_api_import(zap: ZAPv2, target_url: str):
     """

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -147,28 +147,31 @@ def zap_setup_cookie(zap, domain, context_id, cookie_name=None):
     Zap needs to be told to use cookies while scanning.
     This can be done within a context.
     """
-    # Copied from dsp-appsec-zap-automation
-    logging.info("Set up test user in context: " + context_id)
-    username = "testuser"
-    zap.users.new_user(context_id, username)
-    userid = zap.users.users_list(context_id)[0]["id"]
-    if cookie_name:
-        zap.httpsessions.add_default_session_token(cookie_name)
-        zap_access_target(zap, "https://{domain}")
-    # This is the secret sauce for using cookies.
-    # The user above is now associated with the active cookie.
-    # It should always choose the newest one.
-    sessions = zap.httpsessions.sessions(site=domain+":443")
-    session_name = sessions[-1]["session"][0]
-    zap.users.set_authentication_credentials(context_id, 
-                                                userid, 
-                                                "sessionName=" + session_name)
+    try:
+        # Copied from dsp-appsec-zap-automation
+        logging.info("Set up test user in context: " + context_id)
+        username = "testuser"
+        zap.users.new_user(context_id, username)
+        userid = zap.users.users_list(context_id)[0]["id"]
+        if cookie_name:
+            zap.httpsessions.add_default_session_token(cookie_name)
+            zap_access_target(zap, "https://{domain}")
+        # This is the secret sauce for using cookies.
+        # The user above is now associated with the active cookie.
+        # It should always choose the newest one.
+        sessions = zap.httpsessions.sessions(site=domain+":443")
+        session_name = sessions[-1]["session"][0]
+        zap.users.set_authentication_credentials(context_id, 
+                                                    userid, 
+                                                    "sessionName=" + session_name)
 
-    zap.users.set_user_enabled(context_id, userid, True)
-    zap.forcedUser.set_forced_user(context_id, userid)
-    zap.forcedUser.set_forced_user_mode_enabled(True)
-    return username, userid
-
+        zap.users.set_user_enabled(context_id, userid, True)
+        zap.forcedUser.set_forced_user(context_id, userid)
+        zap.forcedUser.set_forced_user_mode_enabled(True)
+        return username, userid
+    except Exception:
+        logging.info("Cookie authenication setup failed.")
+        return None,None
 
 def zap_api_import(zap: ZAPv2, target_url: str):
     """

--- a/zap/src/zap_scan_type.py
+++ b/zap/src/zap_scan_type.py
@@ -15,6 +15,8 @@ class ScanType(str, Enum):
     BASELINE = "Baseline"
     UI = "UI"
     LEOAPP = "LeoApp"
+    IAPUI = "iapui"
+    IAPAPI ="IAPAPI"
 
     def __str__(self):
         return str(self.name).lower()


### PR DESCRIPTION
Add support for IAP token authentication to Zap scanning. 
This adds to new types to the scan types enum to support IAP UI scans and IAP API scans. New functionality for fetching the IAP token from google and adjusted the functionality for setting cookies. Both beehive and Sherlock have been scanned in dev successfully with the new scan types. 