### PR TITLE
[DSEC-902] simplify zap scan request

### DIFF
--- a/sdarq/backend/src/app.py
+++ b/sdarq/backend/src/app.py
@@ -543,11 +543,11 @@ def zap_scan():
     try:
         validate(instance=json_data, schema=zap_scan_schema)
         user_supplied_url = json_data['URL']
-        dev_slack_channel = f"#{json_data['slack_channel']}"
+        channel_name = json_data['slack_channel']
+        dev_slack_channel = f"#{channel_name}" if channel_name != "" else "#appsec_zap_testing"
         publisher = pubsub_v1.PublisherClient()
         zap_topic_path = publisher.topic_path(
             pubsub_project_id, zap_topic_name)
-
         res = requests.get(endpoint, headers=headers, timeout=30)
         res.raise_for_status()
         endpoints = res.json()["results"]
@@ -571,14 +571,15 @@ def zap_scan():
                             "User %s requested to scan via ZAP a service that does not exist in DefectDojo endpoint list",
                             user_email)
                         return jsonify( {'statusText': text_message}), 404
-                severities = parse_json_data.parse_severities(
-                    json_data['severities'])
+
+                # Adds job to pubsub to be picked up by the zap scan code.
+                # CodeDx project is set to an empty string to prevent overwriting reports
+                # The severities field was only used to generate CodeDx reports.
                 publisher.publish(zap_topic_path,
                                   data=message,
                                   URL=service_full_endpoint,
-                                  CODEDX_PROJECT=service_codex_project,
+                                  CODEDX_PROJECT="",
                                   SCAN_TYPE=service_scan_type.name,
-                                  SEVERITIES=severities,
                                   SLACK_CHANNEL=dev_slack_channel,
                                   PRODUCT_ID=product_id)
                 logging.info("User %s requested to scan via ZAP %s service",

--- a/sdarq/backend/src/app.py
+++ b/sdarq/backend/src/app.py
@@ -543,8 +543,7 @@ def zap_scan():
     try:
         validate(instance=json_data, schema=zap_scan_schema)
         user_supplied_url = json_data['URL']
-        channel_name = json_data['slack_channel']
-        dev_slack_channel = f"#{channel_name}" if channel_name != "" else "#appsec_zap_testing"
+        dev_slack_channel = f"#{json_data['slack_channel']}"
         publisher = pubsub_v1.PublisherClient()
         zap_topic_path = publisher.topic_path(
             pubsub_project_id, zap_topic_name)

--- a/sdarq/backend/src/schemas/zap_scan_schema.py
+++ b/sdarq/backend/src/schemas/zap_scan_schema.py
@@ -5,17 +5,10 @@ zap_scan_schema = {
             "type": "string",
             "pattern": "^((http|https)://)[-a-zA-Z0-9@:%._\\+~#?&//=]{2,256}\\.[a-z]{2,6}\\b([-a-zA-Z0-9@:%._\\+~#?&//=]*)$"
         },
-        "severities": {
-            "type": "array",
-            "items": {
-                "enum": ["Critical", "High", "Medium", "Low", "Info"]
-            }
-
-        },
         "slack_channel": {
             "type": "string",
             "pattern": "^[a-z0-9-_]{1}[a-z0-9-_]{0,20}$"
         }
     },
-    "required": ["URL", "severities", "slack_channel"]
+    "required": ["URL", "slack_channel"]
 }

--- a/sdarq/frontend/src/app/service-scan/form.json
+++ b/sdarq/frontend/src/app/service-scan/form.json
@@ -24,35 +24,6 @@
         ]
        },
        {
-        "type": "checkbox",
-        "name": "severities",
-        "title": "Mark which severities you want to be included in the results",
-        "isRequired": true,
-        "choices": [
-         {
-          "value": "Critical",
-          "text": "Critical"
-         },
-         {
-          "value": "High",
-          "text": "High"
-         },
-         {
-          "value": "Medium",
-          "text": "Medium"
-         },
-         {
-          "value": "Low",
-          "text": "Low"
-         },
-         {
-          "value": "Info",
-          "text": "Info"
-         }
-        ],
-        "colCount": 5
-       },
-       {
         "type": "text",
         "name": "slack_channel",
         "title": "Enter slack channel to get scan results ",


### PR DESCRIPTION
Removes the severity option from the scan submission form. Also removes sending codedx project information to the zap scan container, which stops it from being able to upload to codedx projects for off-cycle scans. 

<img width="1021" alt="Screenshot 2024-07-10 at 4 25 59 PM" src="https://github.com/broadinstitute/dsp-appsec-infrastructure-apps/assets/93540258/536d3d22-f0e6-4268-b073-418b5959c700">
