### PR TITLE
Change scan types to better accommodate beehive and Sherlock

### DIFF
--- a/zap/deployment.yaml
+++ b/zap/deployment.yaml
@@ -177,7 +177,7 @@ items:
             - &cron-job-container
               name: zap-trigger
               image: ${ZAP_IMAGE}
-              args: ['trigger', '-s', 'ui', 'iapui']
+              args: ['trigger', '-s', 'ui', 'beehive']
               env:
               - name: GCP_PROJECT_ID
                 value: ${PROJECT_ID}

--- a/zap/deployment.yaml
+++ b/zap/deployment.yaml
@@ -211,7 +211,7 @@ items:
             << : *cron-job-spec
             containers:
             - << : *cron-job-container
-              args: ['trigger', '-s', 'auth', 'api', 'iapapi']
+              args: ['trigger', '-s', 'auth', 'api', 'iapauth']
 
 ---
 apiVersion: storage.cnrm.cloud.google.com/v1beta1

--- a/zap/src/scan.py
+++ b/zap/src/scan.py
@@ -403,7 +403,7 @@ def main(): # pylint: disable=too-many-locals
 
             # optionally, upload them to GCS
             xml_report_url = ""
-            if scan_type in (ScanType.UI, ScanType.LEOAPP, ScanType.IAPUI):
+            if scan_type in (ScanType.UI, ScanType.LEOAPP, ScanType.BEEHIVE):
                 xml_report_url = upload_gcs(
                     bucket_name,
                     scan_type,
@@ -421,7 +421,7 @@ def main(): # pylint: disable=too-many-locals
             clean_uri_path(zap_filename)
 
             #upload scrubbed results in case we need to do a manual upload
-            if scan_type in (ScanType.UI, ScanType.LEOAPP, ScanType.IAPUI):
+            if scan_type in (ScanType.UI, ScanType.LEOAPP, ScanType.BEEHIVE):
                 xml_report_url = upload_gcs(
                     bucket_name,
                     scan_type,
@@ -462,7 +462,7 @@ def main(): # pylint: disable=too-many-locals
                 )
 
             # Upload UI scan XMLs and CodeDx reports to Google Drive.
-            if scan_type in (ScanType.UI, ScanType.LEOAPP, ScanType.IAPUI):
+            if scan_type in (ScanType.UI, ScanType.LEOAPP, ScanType.BEEHIVE):
                 try:
                     logging.info('Setting up the google drive API service for uploading reports.')
 

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -307,22 +307,19 @@ def zap_compliance_scan(
     # AUTH - authenticated with SA, active scan is performed.
     # LEOAPP - authenticated with SA and registered cookie, active scan and ajax spider is performed
     # IAPUI - authenticated with iap bearer token and cookie.
-    #IAPAPI - authenticated with iap bearer token, api spec.
+    #IAPAUTH - authenticated with iap bearer token, api spec.
 
     # Set up context for scan
     context_id = zap_setup_context(zap, project, host)
 
     if scan_type != ScanType.BASELINE:
-        if scan_type == ScanType.IAPUI or scan_type == ScanType.IAPAPI:
+        if scan_type == ScanType.IAPUI or scan_type == ScanType.IAPAUTH:
             client_id = os.getenv('IAP_CLIENT_ID')
             token = zap_set_iap_token(client_id)
             if scan_type == ScanType.IAPUI:
                 logging.info("Setting beehive session cookie.")
                 cookie_name = "__host-beehive_session"
-                try:
-                    zap_setup_cookie(zap, host, context_id, cookie_name)
-                except Exception:
-                    logging.info("Zap failed to find and set the beehive cookie.")
+                zap_setup_cookie(zap, host, context_id, cookie_name)
         else:
             token = zap_sa_auth(zap, env)
         if scan_type == ScanType.LEOAPP:
@@ -335,7 +332,7 @@ def zap_compliance_scan(
                 logging.info("Leo authentication was unsuccessful")
         
 
-    if scan_type == ScanType.API or scan_type == ScanType.IAPAPI:
+    if scan_type == ScanType.API:
         zap_api_import(zap, target_url)
 
     zap.spider.scan(contextname=project, url=target_url)

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -319,7 +319,10 @@ def zap_compliance_scan(
             if scan_type == ScanType.IAPUI:
                 logging.info("Setting beehive session cookie.")
                 cookie_name = "__host-beehive_session"
-                zap_setup_cookie(zap, host, context_id, cookie_name)
+                try:
+                    zap_setup_cookie(zap, host, context_id, cookie_name)
+                except Exception:
+                    logging.info("Zap failed to find and set the beehive cookie.")
         else:
             token = zap_sa_auth(zap, env)
         if scan_type == ScanType.LEOAPP:

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -306,17 +306,17 @@ def zap_compliance_scan(
     # UI - authenticated with SA, active scan and ajax spider is performed.
     # AUTH - authenticated with SA, active scan is performed.
     # LEOAPP - authenticated with SA and registered cookie, active scan and ajax spider is performed
-    # IAPUI - authenticated with iap bearer token and cookie.
+    # BEEHIVE - authenticated with iap bearer token and cookie.
     #IAPAUTH - authenticated with iap bearer token, api spec.
 
     # Set up context for scan
     context_id = zap_setup_context(zap, project, host)
 
     if scan_type != ScanType.BASELINE:
-        if scan_type == ScanType.IAPUI or scan_type == ScanType.IAPAUTH:
+        if scan_type == ScanType.BEEHIVE or scan_type == ScanType.IAPAUTH:
             client_id = os.getenv('IAP_CLIENT_ID')
             token = zap_set_iap_token(client_id)
-            if scan_type == ScanType.IAPUI:
+            if scan_type == ScanType.BEEHIVE:
                 logging.info("Setting beehive session cookie.")
                 cookie_name = "__host-beehive_session"
                 zap_setup_cookie(zap, host, context_id, cookie_name)
@@ -337,7 +337,7 @@ def zap_compliance_scan(
 
     zap.spider.scan(contextname=project, url=target_url)
 
-    if scan_type in (ScanType.UI, ScanType.LEOAPP, ScanType.IAPUI):
+    if scan_type in (ScanType.UI, ScanType.LEOAPP, ScanType.BEEHIVE):
         zap.ajaxSpider.scan(target_url, contextname=project)
 
     zap_wait_for_passive_scan(zap, timeout_in_secs=TIMEOUT_MINS * 60)

--- a/zap/src/zap_scan_type.py
+++ b/zap/src/zap_scan_type.py
@@ -15,7 +15,7 @@ class ScanType(str, Enum):
     BASELINE = "Baseline"
     UI = "UI"
     LEOAPP = "LeoApp"
-    IAPUI = "iapui"
+    BEEHIVE = "beehive"
     IAPAUTH ="IAPAUTH"
 
     def __str__(self):

--- a/zap/src/zap_scan_type.py
+++ b/zap/src/zap_scan_type.py
@@ -16,7 +16,7 @@ class ScanType(str, Enum):
     UI = "UI"
     LEOAPP = "LeoApp"
     IAPUI = "iapui"
-    IAPAPI ="IAPAPI"
+    IAPAUTH ="IAPAUTH"
 
     def __str__(self):
         return str(self.name).lower()


### PR DESCRIPTION
Beehive uses cookies, but Sherlock does not. Making cookies optional so Sherlock can be scanned.
Also threw in exponential back off on closing defect dojo engagements.