### PR TITLE
[DSEC-917] Add dast ticket on product creation

### DIFF
--- a/sdarq/backend/src/app.py
+++ b/sdarq/backend/src/app.py
@@ -154,6 +154,7 @@ def submit():
         appsec_jira_ticket_summury_srcl = 'Add ' + \
             dojo_name + ' to 3rd party dependencies scan tool'
         appsec_jira_ticket_summury_sast = 'Add ' + dojo_name + ' to a SAST tool'
+        appsec_jira_ticket_summury_dast = 'Add ' + dojo_name + ' to DAST tool'
         project_key_id = json_data['JiraProject']
         dev_jira_ticket_summury_alerts = dojo_name + ' security related requirements'
         app_jira_ticket_summury_alerts = 'Track ' + \
@@ -195,6 +196,11 @@ def submit():
         jiranotify.create_board_ticket(
             appsec_jira_project_key,
             appsec_jira_ticket_summury_sast,
+            appsec_jira_ticket_description)
+
+        jiranotify.create_board_ticket(
+            appsec_jira_project_key,
+            appsec_jira_ticket_summury_dast,
             appsec_jira_ticket_description)
 
         jiranotify.create_board_ticket(


### PR DESCRIPTION
When a dev fils out the new service questionnaire several appsec tickets are created, but as of now there has not been one for adding ZAP scanning. This is a small change that adds that ticket. 
<img width="312" alt="Screenshot 2024-08-19 at 4 09 31 PM" src="https://github.com/user-attachments/assets/964aa03a-9efc-4ea0-9707-18d2e7e84a74">
