### PR TITLE
pin cis base image version

### DIFF
--- a/cis/Dockerfile
+++ b/cis/Dockerfile
@@ -1,6 +1,6 @@
 ARG USER="inspec"
 
-FROM us.gcr.io/broad-dsp-gcr-public/base/python:debian AS base
+FROM us.gcr.io/broad-dsp-gcr-public/base/python:3.11-debian AS base
 
 ARG USER
 


### PR DESCRIPTION
cis scanner jobs fail with many failed python imports, and logs show the python version is 3.12

so pin it to 3.11