### PR TITLE
[DSEC-946] The hash used in the javascript pages for terra has changed, this updates our regex.

### DIFF
--- a/zap/src/scan.py
+++ b/zap/src/scan.py
@@ -348,7 +348,7 @@ def slack_alert_without_report(  # pylint: disable=too-many-arguments
         logging.info("Alert sent to Slack channel for DefectDojo upload report")
 
 # match a hash after a hyphen or dot, and only match 8 or 9 characters of hex
-URI_HASH_REGEX = re.compile(r"[-\.][a-fA-F0-9]{8,9}(?![a-fA-F0-9])")
+URI_HASH_REGEX = re.compile(r"[-\.][a-zA-Z0-9]{8,9}(?![a-fA-F0-9])")
 
 def clean_uri_path(xml_report):
     """


### PR DESCRIPTION
Terra and other UI scan sites have changed the hash structure in their javascript and css resources. This small change allows our cleaning regex to recognize the new hash, and remove it from the report. 