### PR TITLE
[DSEC-963] add retry loop

### DIFF
--- a/zap/src/drive_upload.py
+++ b/zap/src/drive_upload.py
@@ -120,7 +120,7 @@ def find_subfolder(folder_structure, target_name, target_folder=None):
     Finds a specific subfolder by name, returns the dict for that folder.
     """
     for child in folder_structure['children']:
-        if child['name'] == target_name:
+        if target_name in child['name']:
             target_folder = child
             return target_folder
         target_folder = find_subfolder(child, target_name)

--- a/zap/src/scan.py
+++ b/zap/src/scan.py
@@ -22,7 +22,7 @@ from codedx_api.CodeDxAPI import CodeDx  # pylint: disable=import-error
 from google.cloud import storage
 from slack_sdk.web import WebClient as SlackClient
 
-from zap import ScanType, zap_compliance_scan, zap_connect
+from zap import ScanType, zap_compliance_scan, zap_shutdown
 
 
 def fetch_dojo_product_name(defect_dojo, defect_dojo_user, defect_dojo_key, product_id):
@@ -518,8 +518,7 @@ def main(): # pylint: disable=too-many-locals
                     dd,
                     target_url
                 )
-                zap = zap_connect()
-                zap.core.shutdown()
+                zap_shutdown()
                 return
             
             # upload its results to Code Dx
@@ -543,8 +542,7 @@ def main(): # pylint: disable=too-many-locals
             logging.info("ready to upload to google drive")
             upload_googledrive(scan_type, zap_filename, codedx_project, cdx_filename, slack_token, slack_channel)
 
-            zap = zap_connect()
-            zap.core.shutdown()
+            zap_shutdown()
             return
         except Exception as error: # pylint: disable=broad-except
             error_message = f"[RETRY-{ attempt }] Exception running Zap Scans: { error }"
@@ -556,8 +554,7 @@ def main(): # pylint: disable=too-many-locals
                 except:
                     logging.error(f"Slack could not post to {slack_channel}")
                 try:
-                    zap = zap_connect()
-                    zap.core.shutdown()
+                    zap_shutdown()
                 except Exception as zap_e: # pylint: disable=broad-except
                     error_message = f"Error shutting down zap: { zap_e }"
                     error_slack_alert(

--- a/zap/src/scan.py
+++ b/zap/src/scan.py
@@ -34,7 +34,7 @@ def fetch_dojo_product_name(defect_dojo, defect_dojo_user, defect_dojo_key, prod
     defect_dojo, defect_dojo_key, defect_dojo_user, debug=False, timeout=120)
     max_retries = int(getenv("MAX_RETRIES", '6'))
     retry_delay = 30
-    for attempt in range(max_retries):
+    for _ in range(max_retries):
         try:
             product = dojo.get_product(product_id=product_id)
             return product.data["name"]
@@ -106,7 +106,7 @@ def defectdojo_upload(product_id: int, zap_filename: str, defect_dojo_key: str, 
     date = datetime.today().strftime("%Y%m%d%H:%M")
     lead_id = fetch_dojo_lead_id(dojo, defect_dojo_user)
 
-# The call to create_engagement sometimes fails. 
+# The call to create_engagement sometimes fails.
     retry_delay = 20
     max_retries = int(getenv("MAX_RETRIES", '5'))
     for attempt in range(max_retries):
@@ -252,7 +252,6 @@ def get_codedx_initial_report(
         file_name=report_file,
         filters=filters,
     )
-
     return report_file
 
 
@@ -382,7 +381,7 @@ def upload_googledrive(scan_type, zap_filename, codedx_project, report_file, sla
     """
     root_id = os.getenv('DRIVE_ROOT_ID', None)
     drive_id = os.getenv('DRIVE_ID', None)
-    if scan_type in (ScanType.BASELINE): 
+    if scan_type in (ScanType.BASELINE):
         return
     try:
         logging.info('Setting up the google drive API service for uploading reports.')
@@ -399,7 +398,6 @@ def upload_googledrive(scan_type, zap_filename, codedx_project, report_file, sla
         date = datetime.today()
         date = drivehelper.adjust_date(date)
         _, xml_folder_dict, zap_raw_folder = drivehelper.get_upload_folders(folder_structure, date)
-        
         file = drivehelper.upload_file_to_drive(zap_filename,
                                                     xml_folder_dict.get('id'),
                                                     drive_id,
@@ -520,7 +518,7 @@ def main(): # pylint: disable=too-many-locals
                 )
                 zap_shutdown()
                 return
-            
+
             # upload its results to Code Dx
             cdx = CodeDx(codedx_url, codedx_api_key)
 

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -75,7 +75,7 @@ def zap_shutdown():
         attempts = int((TIMEOUT_MINS*60)/20)
         for _ in range(attempts):
             shutdown_endpoint = zap.base + "core/action/shutdown/"
-            resp = requests.get(shutdown_endpoint, proxies=proxies,
+            resp = zap.session.requests("GET",shutdown_endpoint, proxies=proxies,
                                 timeout=TIMEOUT_MINS*60)
             logging.info(f"Response code from requesting ZAP shutdown: {resp.status_code}")
             if int(resp.status_code) == 200:

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -60,6 +60,18 @@ def zap_init(target_url: str):
 
     return zap
 
+def zap_shutdown():
+    """
+    Connect to the Zap instance and shut it down.
+    """
+    zap = ZAPv2(proxies={"http": PROXY, "https": PROXY}, apikey=os.getenv("ZAP_API_KEY", ""))
+    try:
+        shutdown_endpoint = zap.base + "core/action/shutdown/"
+        resp = requests.get(shutdown_endpoint, 
+                            timeout=TIMEOUT_MINS*60, verify=False)
+    except:
+        logging.error("failed to shut down zap.")
+    return
 
 def parse_url(url):
     """

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -66,11 +66,20 @@ def zap_shutdown():
     """
     zap = ZAPv2(proxies={"http": PROXY, "https": PROXY}, apikey=os.getenv("ZAP_API_KEY", ""))
     try:
-        shutdown_endpoint = zap.base + "core/action/shutdown/"
-        resp = requests.get(shutdown_endpoint, 
-                            timeout=TIMEOUT_MINS*60, verify=False)
-    except:
+        sleep_time = 20
+        attempts = (TIMEOUT_MINS*60)/20
+        for attempt in range(0, attempts):
+            shutdown_endpoint = zap.base + "core/action/shutdown/"
+            resp = requests.get(shutdown_endpoint, 
+                                timeout=TIMEOUT_MINS*60)
+            logging.info(resp.status_code)
+            if resp.status_code == 200:
+                break
+            time.sleep(sleep_time)
+        
+    except Exception as e:
         logging.error("failed to shut down zap.")
+        logging.error(e)
     return
 
 def parse_url(url):

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -47,7 +47,7 @@ def zap_init(target_url: str):
     enabled = True
     matchregex = True
     matchstring = ".*"
-    requestspersecond = 5
+    requestspersecond = 4
     groupby = "host"
     zap.network.add_rate_limit_rule(description,
                                     enabled,

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -71,23 +71,20 @@ def zap_shutdown():
     logging.info("Attempting to shutdown ZAP")
     apikey = os.getenv("ZAP_API_KEY", "")
     zap = ZAPv2(proxies={"http": PROXY, "https": PROXY}, apikey=apikey)
-    try:
-        sleep_time = 20
-        attempts = int((TIMEOUT_MINS*60)/20)
-        for _ in range(attempts):
+    sleep_time = 20
+    attempts = int((TIMEOUT_MINS*60)/20)
+    for attempt in range(attempts):
+        try:
             shutdown_endpoint = zap.base + "core/action/shutdown/"
             headers = { "X-ZAP-API-Key" : apikey }
             resp = requests.get(shutdown_endpoint, proxies=proxies, headers=headers,
                                 timeout=int(TIMEOUT_MINS*60)/2)
             logging.info(f"Response code from requesting ZAP shutdown: {resp.status_code}")
             if int(resp.status_code) == 200:
-                break
-            time.sleep(sleep_time)
-
-    except Exception as e:
-        logging.error("failed to shut down zap.")
-        logging.error(e)
-
+                return
+        except Exception as e:
+            logging.error(f"An error occured while shutting down zap. Attempt {attempt+1}")
+        time.sleep(sleep_time)
 
 def parse_url(url):
     """

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -68,18 +68,20 @@ def zap_shutdown():
         'http': PROXY,
         'https': PROXY,
         }
+    logging.info("Attempting to shutdown ZAP")
     zap = ZAPv2(proxies={"http": PROXY, "https": PROXY}, apikey=os.getenv("ZAP_API_KEY", ""))
     try:
         sleep_time = 20
         attempts = int((TIMEOUT_MINS*60)/20)
-        for attempt in range(attempts):
+        for _ in range(attempts):
             shutdown_endpoint = zap.base + "core/action/shutdown/"
             resp = requests.get(shutdown_endpoint, proxies=proxies,
                                 timeout=TIMEOUT_MINS*60)
-            logging.info(resp.status_code)
+            logging.info(f"Response code from requesting ZAP shutdown: {resp.status_code}")
             if int(resp.status_code) == 200:
                 break
             time.sleep(sleep_time)
+            
         
     except Exception as e:
         logging.error("failed to shut down zap.")

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -64,13 +64,17 @@ def zap_shutdown():
     """
     Connect to the Zap instance and shut it down.
     """
+    proxies = {
+        'http': PROXY,
+        'https': PROXY,
+        }
     zap = ZAPv2(proxies={"http": PROXY, "https": PROXY}, apikey=os.getenv("ZAP_API_KEY", ""))
     try:
         sleep_time = 20
         attempts = int((TIMEOUT_MINS*60)/20)
         for attempt in range(attempts):
             shutdown_endpoint = zap.base + "core/action/shutdown/"
-            resp = requests.get(shutdown_endpoint, 
+            resp = requests.get(shutdown_endpoint, proxies=proxies,
                                 timeout=TIMEOUT_MINS*60)
             logging.info(resp.status_code)
             if int(resp.status_code) == 200:

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -67,13 +67,13 @@ def zap_shutdown():
     zap = ZAPv2(proxies={"http": PROXY, "https": PROXY}, apikey=os.getenv("ZAP_API_KEY", ""))
     try:
         sleep_time = 20
-        attempts = (TIMEOUT_MINS*60)/20
-        for attempt in range(0, attempts):
+        attempts = int((TIMEOUT_MINS*60)/20)
+        for attempt in range(attempts):
             shutdown_endpoint = zap.base + "core/action/shutdown/"
             resp = requests.get(shutdown_endpoint, 
                                 timeout=TIMEOUT_MINS*60)
             logging.info(resp.status_code)
-            if resp.status_code == 200:
+            if int(resp.status_code) == 200:
                 break
             time.sleep(sleep_time)
         

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -21,7 +21,7 @@ from zap_common import (wait_for_zap_start, zap_access_target,
 from zap_scan_type import ScanType
 from zapv2 import ZAPv2
 
-TIMEOUT_MINS = 5
+TIMEOUT_MINS = 6
 zap_port = int(os.getenv("ZAP_PORT", ""))
 PROXY = f"http://localhost:{zap_port}"
 
@@ -320,7 +320,7 @@ def get_hail_token():
         "aud": "https://www.googleapis.com/oauth2/v4/token",
         "iat": now,
         "scope": scope,
-        "exp": now + 300,  # 5m
+        "exp": now + 3000,  # 50m
         "iss": creds['client_email'],
     }
     encoded_assertion = jwt.encode(assertion, creds['private_key'], algorithm='RS256')

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -69,14 +69,16 @@ def zap_shutdown():
         'https': PROXY,
         }
     logging.info("Attempting to shutdown ZAP")
-    zap = ZAPv2(proxies={"http": PROXY, "https": PROXY}, apikey=os.getenv("ZAP_API_KEY", ""))
+    apikey = os.getenv("ZAP_API_KEY", "")
+    zap = ZAPv2(proxies={"http": PROXY, "https": PROXY}, apikey=apikey)
     try:
         sleep_time = 20
         attempts = int((TIMEOUT_MINS*60)/20)
         for _ in range(attempts):
             shutdown_endpoint = zap.base + "core/action/shutdown/"
-            resp = zap.session.requests("GET",shutdown_endpoint, proxies=proxies,
-                                timeout=TIMEOUT_MINS*60)
+            headers = { "X-ZAP-API-Key" : apikey }
+            resp = requests.get(shutdown_endpoint, proxies=proxies, headers=headers,
+                                timeout=int(TIMEOUT_MINS*60)/2)
             logging.info(f"Response code from requesting ZAP shutdown: {resp.status_code}")
             if int(resp.status_code) == 200:
                 break

--- a/zap/src/zap.py
+++ b/zap/src/zap.py
@@ -83,12 +83,11 @@ def zap_shutdown():
             if int(resp.status_code) == 200:
                 break
             time.sleep(sleep_time)
-            
-        
+
     except Exception as e:
         logging.error("failed to shut down zap.")
         logging.error(e)
-    return
+
 
 def parse_url(url):
     """


### PR DESCRIPTION
Several small pipeline changes to try and improve reliability. 
A new retry loop around creating an engagement in defect dojo. Several scans were consistently failing on this step, and hopefully this helps to alleviate this issue. 
Broke out the zap shutdown action, and tried to fix the intermittent timeout issue. 

The TIMEOUT_MINS value was increased by one. This value is used for communicating with the local instance of ZAP. There had been an increase in timeouts when connecting with ZAP from the zap-scans controller, and this is an attempt to reduce those timeouts.

The requestspersecond value was decreased by 1. This is across all scans as an attempt to reduce issues where the scanner was encountering 502 or 503 errors while scanning. 