### PR TITLE
add alternate route for cis scanning page

### DIFF
--- a/sdarq/frontend/src/app/app-routing.module.ts
+++ b/sdarq/frontend/src/app/app-routing.module.ts
@@ -35,6 +35,7 @@ const routes: Routes = [
   { path: 'generalServiceQuestionnaire', component: FormComponent },
   { path: '3rd-party-app-questionnaire', component: AppFormComponent },
   { path: 'new-3rd-party-app', component: AppsMainpageComponent },
+  { path:  'cis/scan', component: CisScanComponent },
   { path: 'gcp-project-security-posture/latest', component: CisComponent },
   { path: 'gcp-project-security-posture/results', component: CisResultsComponent },
   { path: 'gcp-project-security-posture/scan', component: CisScanComponent },


### PR DESCRIPTION
Some older documentation has the path /cis/scan for starting a cis scan. This is an attempt to add an alternate route so old documentation is still valid. 