### PR TITLE
update dojo

### DIFF
--- a/defectdojo/Dockerfile.django
+++ b/defectdojo/Dockerfile.django
@@ -1,4 +1,4 @@
-FROM defectdojo/defectdojo-django:2.42.3 as dd
+FROM defectdojo/defectdojo-django:2.39.4 as dd
 
 FROM dd as patch
 

--- a/defectdojo/Dockerfile.django
+++ b/defectdojo/Dockerfile.django
@@ -1,4 +1,4 @@
-FROM defectdojo/defectdojo-django:2.35.2 as dd
+FROM defectdojo/defectdojo-django:2.43.4 as dd
 
 FROM dd as patch
 

--- a/defectdojo/Dockerfile.django
+++ b/defectdojo/Dockerfile.django
@@ -1,4 +1,4 @@
-FROM defectdojo/defectdojo-django:2.43.4 as dd
+FROM defectdojo/defectdojo-django:2.42.3 as dd
 
 FROM dd as patch
 

--- a/defectdojo/Dockerfile.django
+++ b/defectdojo/Dockerfile.django
@@ -1,4 +1,4 @@
-FROM defectdojo/defectdojo-django:2.35.2 as dd
+FROM defectdojo/defectdojo-django:2.36.3 as dd
 
 FROM dd as patch
 

--- a/defectdojo/Dockerfile.django
+++ b/defectdojo/Dockerfile.django
@@ -1,4 +1,4 @@
-FROM defectdojo/defectdojo-django:2.36.3 as dd
+FROM defectdojo/defectdojo-django:2.44.1 as dd
 
 FROM dd as patch
 

--- a/defectdojo/Dockerfile.django
+++ b/defectdojo/Dockerfile.django
@@ -1,4 +1,4 @@
-FROM defectdojo/defectdojo-django:2.44.2 as dd
+FROM defectdojo/defectdojo-django:2.35.2 as dd
 
 FROM dd as patch
 

--- a/defectdojo/Dockerfile.django
+++ b/defectdojo/Dockerfile.django
@@ -1,4 +1,4 @@
-FROM defectdojo/defectdojo-django:2.39.4 as dd
+FROM defectdojo/defectdojo-django:2.35.2 as dd
 
 FROM dd as patch
 

--- a/defectdojo/Dockerfile.django
+++ b/defectdojo/Dockerfile.django
@@ -1,4 +1,4 @@
-FROM defectdojo/defectdojo-django:2.35.2 as dd
+FROM defectdojo/defectdojo-django:2.44.2 as dd
 
 FROM dd as patch
 

--- a/zap/src/defectdojo_apiv2.py
+++ b/zap/src/defectdojo_apiv2.py
@@ -689,7 +689,7 @@ class DefectDojoAPIv2(object):
             print(filedata)
         
         if os.path.splitext(file)[-1].lower() == ".xml":
-             filedata = {'file':('report.xml',filedata,'text/xml')}
+             filedata = ('report.xml',filedata,'text/xml')
 
         data = {
             'file': filedata,

--- a/zap/src/defectdojo_apiv2.py
+++ b/zap/src/defectdojo_apiv2.py
@@ -689,7 +689,7 @@ class DefectDojoAPIv2(object):
             print("filedata:")
             print(filedata)
 
-        filedata = ('report.xml', filedata, mimetypes.guess_file_type(file)[0])
+        filedata = ('report.xml', filedata, mimetypes.guess_type(file)[0])
 
         data = {
             'file': filedata,

--- a/zap/src/defectdojo_apiv2.py
+++ b/zap/src/defectdojo_apiv2.py
@@ -1,4 +1,5 @@
 import json
+import mimetypes
 import os
 
 import requests
@@ -687,9 +688,8 @@ class DefectDojoAPIv2(object):
         if self.debug:
             print("filedata:")
             print(filedata)
-        
-        if os.path.splitext(file)[-1].lower() == ".xml":
-             filedata = ('report.xml',filedata,'text/xml')
+
+        filedata = ('report.xml', filedata, mimetypes.guess_file_type(file)[0])
 
         data = {
             'file': filedata,

--- a/zap/src/defectdojo_apiv2.py
+++ b/zap/src/defectdojo_apiv2.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 import requests
 import requests.exceptions
@@ -686,6 +687,9 @@ class DefectDojoAPIv2(object):
         if self.debug:
             print("filedata:")
             print(filedata)
+        
+        if os.path.splitext(file)[-1].lower() == ".xml":
+             filedata = {'file':('report.xml',filedata,'text/xml')}
 
         data = {
             'file': filedata,


### PR DESCRIPTION
Updating DefectDojo to a more recent version. 

This requires updating postgresql to at least version 14. 

The upload functionality now requires the content-type be set for the file portion of the multi-part form. There may be issues with any automation outside of DAIA that uploads to defect dojo. 