### PR TITLE
sdarq allow longer slack channels for cis and zap scans

### DIFF
--- a/sdarq/frontend/src/app/cis-scan/form.json
+++ b/sdarq/frontend/src/app/cis-scan/form.json
@@ -50,7 +50,7 @@
             {
              "type": "regex",
              "text": "Please enter a valid channel",
-             "regex": "^[a-z0-9-_]{1}[a-z0-9-_]{0,20}$"
+             "regex": "^[a-z0-9-_]{1}[a-z0-9-_]{0,40}$"
             }
            ],
         "isRequired": true

--- a/sdarq/frontend/src/app/service-scan/form.json
+++ b/sdarq/frontend/src/app/service-scan/form.json
@@ -32,7 +32,7 @@
          {
           "type": "regex",
           "text": "Please enter a valid channel",
-          "regex": "^[a-z0-9-_]{1}[a-z0-9-_]{0,20}$"
+          "regex": "^[a-z0-9-_]{1}[a-z0-9-_]{0,40}$"
          }
         ]
        }


### PR DESCRIPTION
Sdarq UI limited slack channels to 20 characters. Now the limit is 40.