### PR TITLE
[DSEC-965] add csv report for hail

### DIFF
--- a/zap/src/scan.py
+++ b/zap/src/scan.py
@@ -453,6 +453,7 @@ def hail_compliance_export(results_json, project_name):
             results[key][1] = str(result.get('id'))
             results[key][6] = f"{results[key][6]}, \n{result.get('location').get('path').get('path')}"
     
+    logging.info("Writing CSV report")
     report_date = datetime.now()
     report_name = f'{project_name.replace("-", "_")}_report_{report_date:%Y%m%d}.csv'
     with open(report_name, "w", newline='') as csvfile:
@@ -639,6 +640,7 @@ def main(): # pylint: disable=too-many-locals
             # Upload Terra scan XMLs and CodeDx reports to Google Drive.
             logging.info("ready to upload to google drive")
             if scan_type in (ScanType.HAILAPI, ScanType.HAILAUTH):
+                logging.info("Pulling findings JSON for hail to build report CSV.")
                 findings_json = get_codedx_findings_json(cdx, product_id)
                 report_name = hail_compliance_export(findings_json, codedx_project)
 

--- a/zap/src/scan.py
+++ b/zap/src/scan.py
@@ -462,7 +462,7 @@ def hail_compliance_export(results_json, project_name):
             report_writer.writerow(line)
     return report_name
     
-def upload_googledrive(scan_type, zap_filename, codedx_project, report_file, slack_token, slack_channel):
+def upload_googledrive(scan_type, zap_filename, codedx_project, report_file, slack_token, slack_channel, csv_report_name=None):
     """
     Uploads the xml and initial codedx reports to the appropriate google drive location,
     according to scan type.
@@ -504,9 +504,8 @@ def upload_googledrive(scan_type, zap_filename, codedx_project, report_file, sla
         logging.info(f'The report {report_file} has been uploaded.')
         if scan_type in (ScanType.HAILAPI, ScanType.HAILAUTH):
             # export the raw report in a format that can be used to generate POAMs
-            findings_json = get_codedx_findings_json()
-            report_name = hail_compliance_export(findings_json, codedx_project)
-            file3 = drivehelper.upload_file_to_drive(report_name,
+            
+            file3 = drivehelper.upload_file_to_drive(csv_report_name,
                                                         zap_raw_folder.get('id'),
                                                         drive_id,
                                                         drive_service)
@@ -639,7 +638,12 @@ def main(): # pylint: disable=too-many-locals
 
             # Upload Terra scan XMLs and CodeDx reports to Google Drive.
             logging.info("ready to upload to google drive")
-            upload_googledrive(scan_type, zap_filename, codedx_project, cdx_filename, slack_token, slack_channel)
+            if scan_type in (ScanType.HAILAPI, ScanType.HAILAUTH):
+                findings_json = get_codedx_findings_json(cdx, product_id)
+                report_name = hail_compliance_export(findings_json, codedx_project)
+
+
+            upload_googledrive(scan_type, zap_filename, codedx_project, cdx_filename, slack_token, slack_channel, report_name)
 
             zap_shutdown()
             return

--- a/zap/src/scan.py
+++ b/zap/src/scan.py
@@ -638,6 +638,7 @@ def main(): # pylint: disable=too-many-locals
                 scan_type,
             )
 
+            report_name = None
             # Upload Terra scan XMLs and CodeDx reports to Google Drive.
             logging.info("ready to upload to google drive")
             if scan_type in (ScanType.HAILAPI, ScanType.HAILAUTH):

--- a/zap/src/scan.py
+++ b/zap/src/scan.py
@@ -404,7 +404,7 @@ def get_codedx_findings_json(cdx,codedx_project):
                 }
     return cdx.get_finding_table(project_id, options, config,  )
 
-def hail_compliance_export(results_json, project_name):
+def hail_compliance_export(results_json, project_name, cdx_report_filename):
     """
     Helper function to create a CSV file in the POAM format of the current raw findings
     """
@@ -428,7 +428,7 @@ def hail_compliance_export(results_json, project_name):
         result_line.append("")
         result_line.append(name)
         result_line.append(result.get("descriptions").get("general").get("content"))
-        result_line.append("put file location here")
+        result_line.append(cdx_report_filename)
         result_line.append(result.get("descriptor").get("hierarchy")[0])
         result_line.append(result.get("location").get("path").get("path"))
         result_line.append(result.get("firstSeenOn"))
@@ -644,7 +644,7 @@ def main(): # pylint: disable=too-many-locals
             if scan_type in (ScanType.HAILAPI, ScanType.HAILAUTH):
                 logging.info("Pulling findings JSON for hail to build report CSV.")
                 findings_json = get_codedx_findings_json(cdx, codedx_project)
-                report_name = hail_compliance_export(findings_json, codedx_project)
+                report_name = hail_compliance_export(findings_json, codedx_project, cdx_filename)
 
 
             upload_googledrive(scan_type, zap_filename, codedx_project, cdx_filename, slack_token, slack_channel, report_name)

--- a/zap/src/scan.py
+++ b/zap/src/scan.py
@@ -379,6 +379,7 @@ def get_codedx_findings_json(cdx,codedx_project):
     """
     Raw report findings_json
     """
+    project_id = cdx.get_project_id(codedx_project)
     options = ["descriptor",
                "issue",
                "descriptions",
@@ -401,7 +402,7 @@ def get_codedx_findings_json(cdx,codedx_project):
                 },
                 "pagination":{"perPage":500,"page":1}
                 }
-    return cdx.get_finding_table(codedx_project, options, config,  )
+    return cdx.get_finding_table(project_id, options, config,  )
 
 def hail_compliance_export(results_json, project_name):
     """
@@ -641,7 +642,7 @@ def main(): # pylint: disable=too-many-locals
             logging.info("ready to upload to google drive")
             if scan_type in (ScanType.HAILAPI, ScanType.HAILAUTH):
                 logging.info("Pulling findings JSON for hail to build report CSV.")
-                findings_json = get_codedx_findings_json(cdx, product_id)
+                findings_json = get_codedx_findings_json(cdx, codedx_project)
                 report_name = hail_compliance_export(findings_json, codedx_project)
 
 

--- a/zap/src/scan.py
+++ b/zap/src/scan.py
@@ -451,7 +451,7 @@ def hail_compliance_export(results_json, project_name):
         else:
             results[key] = result_line
             results[key][1] = str(result.get('id'))
-            results[key][6] = results[key][6] + f", \n{result.get("location").get("path").get("path")}"
+            results[key][6] = f"{results[key][6]}, \n{result.get('location').get('path').get('path')}"
     
     report_date = datetime.now()
     report_name = f'{project_name.replace("-", "_")}_report_{report_date:%Y%m%d}.csv'


### PR DESCRIPTION
Hail's continuous monitoring will be run by a different team. This adds a summary CSV extract to the weekly run to help simplify the process of doing reporting. 
This has not been added to Terra, as the extract does not currently support the way those findings are stored in Codedx. Adding that functionality should be a future task, if we decide we want this extract for Terra as well. 