### PR TITLE
[dsec-969] Update zap container image location

### DIFF
--- a/zap/Dockerfile
+++ b/zap/Dockerfile
@@ -1,4 +1,4 @@
-FROM softwaresecurityproject/zap-stable AS zap
+FROM zaproxy/zap-stable AS zap
 
 FROM us.gcr.io/broad-dsp-gcr-public/base/python:3.10-debian AS base
 

--- a/zap/deployment.yaml
+++ b/zap/deployment.yaml
@@ -19,7 +19,7 @@ data:
 
         containers:
         - name: zap
-          image: softwaresecurityproject/zap-stable
+          image: ghcr.io/zaproxy/zaproxy:bare
           volumeMounts:
             - name: shared-data
               mountPath: ${VOLUME_SHARE}


### PR DESCRIPTION
Zap has changes the container location again. This updates the location and uses the bare (slim) image for the zap scanner. 