### PR TITLE
update dojo to latest

### DIFF
--- a/defectdojo/Dockerfile.django
+++ b/defectdojo/Dockerfile.django
@@ -1,4 +1,4 @@
-FROM defectdojo/defectdojo-django:2.44.1 as dd
+FROM defectdojo/defectdojo-django:2.48.0 as dd
 
 FROM dd as patch
 


### PR DESCRIPTION
Bumps the version of defectdojo to 2.48.0. It worked in manual tests for importing and updating results. 